### PR TITLE
Various improvements

### DIFF
--- a/commands/filters.js
+++ b/commands/filters.js
@@ -99,7 +99,6 @@ module.exports = {
                 time: 60000
             });
 
-            console.log(confirmation.values);
             queue.filters.ffmpeg.setInputArgs([
                 '-threads',
                 filterThreadAmount,

--- a/commands/play.js
+++ b/commands/play.js
@@ -27,12 +27,11 @@ module.exports = {
         }
 
         const player = useMainPlayer();
-        const queue = useQueue(interaction.guild.id);
         const query = interaction.options.getString('query');
 
-        const results = await player.search(query);
+        const searchResult = await player.search(query);
 
-        if (!results || results.tracks.length === 0) {
+        if (!searchResult || searchResult.tracks.length === 0) {
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
@@ -44,34 +43,96 @@ module.exports = {
             });
         }
 
-        const { track } = await player.play(
-            interaction.member.voice.channel,
-            query,
-            {
-                requestedBy: interaction.user,
-                nodeOptions: {
-                    leaveOnEmptyCooldown: 60000,
-                    leaveOnEndCooldown: 60000,
-                    leaveOnStopCooldown: 60000
+        try {
+            const { track } = await player.play(
+                interaction.member.voice.channel,
+                searchResult.tracks[0].url,
+                {
+                    requestedBy: interaction.user,
+                    nodeOptions: {
+                        leaveOnEmptyCooldown: 60000,
+                        leaveOnEndCooldown: 60000,
+                        leaveOnStopCooldown: 60000
+                    }
                 }
-            }
-        );
+            );
 
-        // TODO: Add a check to see if the queue is empty, and if so, add a message to the embed saying that the track is now playing.
-        // TODO: YouTube thumbnail not shown? Different url than track.thumbnail?
-        return await interaction.editReply({
-            embeds: [
-                new EmbedBuilder()
-                    .setAuthor({
-                        name: interaction.user.username,
-                        iconURL: interaction.user.avatarURL()
-                    })
-                    .setDescription(
-                        `**Added to queue**\n\`[${track.duration}]\` **[${track.title}](${track.url})**`
-                    )
-                    .setThumbnail(track.thumbnail)
-                    .setColor(embedColors.colorSuccess)
-            ]
-        });
+            return await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setAuthor({
+                            name: interaction.user.username,
+                            iconURL: interaction.user.avatarURL()
+                        })
+                        .setDescription(
+                            `**Added to queue**\n\`[${track.duration}]\` **[${track.title}](${track.url})**`
+                        )
+                        .setThumbnail(track.thumbnail)
+                        .setColor(embedColors.colorSuccess)
+                ]
+            });
+        } catch (e) {
+            if (e.message.includes('Could not extract stream for this track')) {
+                if (searchResult.tracks.length > 1) {
+                    try {
+                        const { track } = await player.play(
+                            interaction.member.voice.channel,
+                            searchResult.tracks[1].url,
+                            {
+                                requestedBy: interaction.user,
+                                nodeOptions: {
+                                    leaveOnEmptyCooldown: 60000,
+                                    leaveOnEndCooldown: 60000,
+                                    leaveOnStopCooldown: 60000
+                                }
+                            }
+                        );
+
+                        return await interaction.editReply({
+                            embeds: [
+                                new EmbedBuilder()
+                                    .setAuthor({
+                                        name: interaction.user.username,
+                                        iconURL: interaction.user.avatarURL()
+                                    })
+                                    .setDescription(
+                                        `**Added to queue**\n\`[${track.duration}]\` **[${track.title}](${track.url})**`
+                                    )
+                                    .setThumbnail(track.thumbnail)
+                                    .setColor(embedColors.colorSuccess)
+                            ]
+                        });
+                    } catch (e) {
+                        if (
+                            e.message.includes(
+                                'Could not extract stream for this track'
+                            )
+                        ) {
+                            return await interaction.editReply({
+                                embeds: [
+                                    new EmbedBuilder()
+                                        .setDescription(
+                                            `**Failed**\nFound a result for query \`${query}\` with source ${searchResult.tracks[1].url}, but was unable to extract audio stream from track.\n\nThis is most likely due to audio source blocking download from the bot. Please try another track or refine your query.`
+                                        )
+                                        .setColor(embedColors.colorError)
+                                ]
+                            });
+                        }
+                    }
+                } else {
+                    return await interaction.editReply({
+                        embeds: [
+                            new EmbedBuilder()
+                                .setDescription(
+                                    `**Failed**\nFound a result for query \`${query}\` with source ${searchResult.tracks[0].url}, but was unable to extract audio stream from track.\n\nThis is most likely due to audio source blocking download from the bot or unsupported audio encoding. Please try another track or refine your query.`
+                                )
+                                .setColor(embedColors.colorError)
+                        ]
+                    });
+                }
+            } else {
+                throw e;
+            }
+        }
     }
 };


### PR DESCRIPTION
Handle Could not extract stream for this track error in `/play` command.

Handles the error by trying the second result, if any. If not, reply to user with a message explaining audio cannot be extracted, instead of "Unexpected Error" message.