### PR TITLE
Various fixes and adjustments after v1.1

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -71,9 +71,9 @@ module.exports = {
                         .setDescription(
                             `**Added playlist to queue**\n\`[${
                                 track.duration
-                            }]\` **[${track.title}](${track.url})**\n\nAnd \`${
+                            }]\` **[${track.title}](${track.url})**\n\nAnd **${
                                 searchResult.tracks.length - 1
-                            }\` more tracks... \`/queue\` to view all.`
+                            }** more tracks... \`/queue\` to view all.`
                         )
                         .setThumbnail(track.thumbnail)
                         .setColor(embedColors.colorSuccess)

--- a/commands/play.js
+++ b/commands/play.js
@@ -45,6 +45,22 @@ module.exports = {
             });
         }
 
+        if (
+            searchResult.tracks[0].raw.live &&
+            searchResult.tracks[0].raw.duration === 0 &&
+            searchResult.tracks[0].source === 'youtube'
+        ) {
+            return await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setDescription(
+                            `**Unsupported Source**\nThis audio source is a YouTube live stream, which is currently not a supported format.\n\n_If you think that this is incorrect, please submit a bug report in the bot [support server](https://discord.gg/t6Bm8wPpXB)._`
+                        )
+                        .setColor(embedColors.colorWarning)
+                ]
+            });
+        }
+
         const { track } = await player.play(
             interaction.member.voice.channel,
             searchResult,
@@ -60,6 +76,16 @@ module.exports = {
             }
         );
 
+        if (track.source === 'arbitrary') {
+            track.thumbnail =
+                'https://raw.githubusercontent.com/mariusbegby/cadence-discord-bot/main/icons/Cadence-icon-rounded-128px.png';
+        }
+
+        let durationFormat =
+            track.raw.duration === 0 || track.duration === '0:00'
+                ? ''
+                : `\`[${track.duration}]\``;
+
         if (searchResult.playlist && searchResult.tracks.length > 1) {
             return await interaction.editReply({
                 embeds: [
@@ -69,9 +95,9 @@ module.exports = {
                             iconURL: interaction.user.avatarURL()
                         })
                         .setDescription(
-                            `**Added playlist to queue**\n\`[${
-                                track.duration
-                            }]\` **[${track.title}](${track.url})**\n\nAnd **${
+                            `**Added playlist to queue**\n${durationFormat} **[${
+                                track.title
+                            }](${track.url})**\n\nAnd **${
                                 searchResult.tracks.length - 1
                             }** more tracks... \`/queue\` to view all.`
                         )
@@ -89,7 +115,7 @@ module.exports = {
                         iconURL: interaction.user.avatarURL()
                     })
                     .setDescription(
-                        `**Added to queue**\n\`[${track.duration}]\` **[${track.title}](${track.url})**`
+                        `**Added to queue**\n${durationFormat} **[${track.title}](${track.url})**`
                     )
                     .setThumbnail(track.thumbnail)
                     .setColor(embedColors.colorSuccess)

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -30,7 +30,7 @@ module.exports = {
         let queueString = '';
 
         if (!queue) {
-            queueString = `**Failed**\nThere are no tracks in the queue. Add tracks with \`/play\`!`;
+            queueString = `There are no tracks in the queue. Add tracks with \`/play\`!`;
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -68,9 +68,14 @@ module.exports = {
             queueString = queue.tracks.data
                 .slice(page * 10, page * 10 + 10)
                 .map((track, index) => {
-                    return `**${page * 10 + index + 1}.** \`[${
-                        track.duration
-                    }]\` [${track.title}](${track.url})`;
+                    let durationFormat =
+                        track.raw.duration === 0 || track.duration === '0:00'
+                            ? ''
+                            : `\`[${track.duration}]\``;
+
+                    return `**${page * 10 + index + 1}.** ${durationFormat} [${
+                        track.title
+                    }](${track.url})`;
                 })
                 .join('\n');
         }
@@ -97,6 +102,13 @@ module.exports = {
                 queue: false,
                 length: 13
             });
+
+            if (
+                currentTrack.raw.duration === 0 ||
+                currentTrack.duration === '0:00'
+            ) {
+                bar = 'No duration available.';
+            }
 
             return await interaction.editReply({
                 embeds: [

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -40,6 +40,9 @@ module.exports = {
                         })
                         .setDescription(`**Queue**\n${queueString}`)
                         .setColor(embedColors.colorInfo)
+                        .setFooter({
+                            text: `Page 1 of 1`
+                        })
                 ]
             });
         }


### PR DESCRIPTION
- Improved reply messages.
- Add page numbers also on empty queue when performing `/queue`.
- Better handling and formatting of duration in `/play` and `/queue` commands.
- Changed icon for local files (`arbitrary` source) to Cadence icon instead of iTunes.
- Handle unsupported YouTube live stream source by informing user about unsupported format.