### PR TITLE
Change default player volume

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { useMainPlayer } = require('discord-player');
 const { EmbedBuilder } = require('discord.js');
-const { embedColors } = require('../config.json');
+const { embedColors, playerOptions } = require('../config.json');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -67,11 +67,15 @@ module.exports = {
             {
                 requestedBy: interaction.user,
                 nodeOptions: {
-                    leaveOnEmptyCooldown: 60000,
-                    leaveOnEndCooldown: 60000,
-                    leaveOnStopCooldown: 60000,
-                    maxSize: 10000,
-                    maxHistorySize: 100
+                    leaveOnEmpty: playerOptions.leaveOnEmpty ?? true,
+                    leaveOnEmptyCooldown: playerOptions.leaveOnEmptyCooldown ?? 60000,
+                    leaveOnEnd: playerOptions.leaveOnEnd ?? true,
+                    leaveOnEndCooldown: playerOptions.leaveOnEndCooldown ?? 60000,
+                    leaveOnStop: playerOptions.leaveOnStop ?? true,
+                    leaveOnStopCooldown: playerOptions.leaveOnStopCooldown ?? 60000,
+                    maxSize: playerOptions.maxQueueSize ?? 1000,
+                    maxHistorySize: playerOptions.maxHistorySize ?? 100,
+                    volume: playerOptions.defaultVolume ?? 50
                 }
             }
         );

--- a/commands/play.js
+++ b/commands/play.js
@@ -68,11 +68,14 @@ module.exports = {
                 requestedBy: interaction.user,
                 nodeOptions: {
                     leaveOnEmpty: playerOptions.leaveOnEmpty ?? true,
-                    leaveOnEmptyCooldown: playerOptions.leaveOnEmptyCooldown ?? 60000,
+                    leaveOnEmptyCooldown:
+                        playerOptions.leaveOnEmptyCooldown ?? 60000,
                     leaveOnEnd: playerOptions.leaveOnEnd ?? true,
-                    leaveOnEndCooldown: playerOptions.leaveOnEndCooldown ?? 60000,
+                    leaveOnEndCooldown:
+                        playerOptions.leaveOnEndCooldown ?? 60000,
                     leaveOnStop: playerOptions.leaveOnStop ?? true,
-                    leaveOnStopCooldown: playerOptions.leaveOnStopCooldown ?? 60000,
+                    leaveOnStopCooldown:
+                        playerOptions.leaveOnStopCooldown ?? 60000,
                     maxSize: playerOptions.maxQueueSize ?? 1000,
                     maxHistorySize: playerOptions.maxHistorySize ?? 100,
                     volume: playerOptions.defaultVolume ?? 50

--- a/config.json.example
+++ b/config.json.example
@@ -10,6 +10,17 @@
         "colorInfo": "#5865F2",
         "colorNote": "#80848E"
     },
+    "playerOptions": {
+        "leaveOnEmpty": true,
+        "leaveOnEmptyCooldown": 60000,
+        "leaveOnEnd": true,
+        "leaveonEndCooldown": 60000,
+        "leaveOnStop": true,
+        "leaveOnStopCooldown": 60000,
+        "defaultVolume": 50,
+        "maxQueueSize": 1000,
+        "maxHistorySize": 100
+    },
     "minimumLogLevel": "debug",
     "minimumLogLevelConsole": "info",
     "filterThreadAmount": "4",


### PR DESCRIPTION
- Set default player volume to 50% instead of 100%.
- Player options can now be configured from config.json
- Updated config.json example with new options