### PR TITLE
v1.3 update

### DIFF
--- a/commands/filters.js
+++ b/commands/filters.js
@@ -99,6 +99,8 @@ module.exports = {
                 time: 60000
             });
 
+            confirmation.deferUpdate();
+
             queue.filters.ffmpeg.setInputArgs([
                 '-threads',
                 filterThreadAmount,
@@ -164,16 +166,11 @@ module.exports = {
                 components: []
             });
         } catch (e) {
-            return await interaction.editReply({
-                embeds: [
-                    new EmbedBuilder()
-                        .setDescription(
-                            `**Cancelled**\nNo confirmation received within 1 minute.`
-                        )
-                        .setColor(embedColors.colorWarning)
-                ],
-                components: []
-            });
+            if (e.code === 'InteractionCollectorError') {
+                return;
+            }
+
+            throw e;
         }
     }
 };

--- a/commands/nowplaying.js
+++ b/commands/nowplaying.js
@@ -1,0 +1,208 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { useQueue } = require('discord-player');
+const { EmbedBuilder, ActionRowBuilder, ButtonBuilder } = require('discord.js');
+const { embedColors, progressBarOptions } = require('../config.json');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('nowplaying')
+        .setDescription('Show information about the track currently playing.'),
+    run: async ({ interaction }) => {
+        if (!interaction.member.voice.channel) {
+            return await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setDescription(
+                            `**Failed**\nYou need to be in a voice channel to use this command.`
+                        )
+                        .setColor(embedColors.colorWarning)
+                ]
+            });
+        }
+
+        const queue = useQueue(interaction.guild.id);
+
+        if (!queue) {
+            return await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setDescription(
+                            `**Failed**\nThere are no tracks in the queue. Add tracks with \`/play\`!`
+                        )
+                        .setColor(embedColors.colorWarning)
+                ]
+            });
+        }
+
+        if (!queue.currentTrack) {
+            return await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setDescription(
+                            `**Failed**\nThere are no tracks in the queue or currently playing.`
+                        )
+                        .setColor(embedColors.colorWarning)
+                ]
+            });
+        }
+
+        const sourceStringsFormatted = {
+            youtube: 'YouTube',
+            soundcloud: 'SoundCloud',
+            spotify: 'Spotify',
+            apple_music: 'Apple Music',
+            arbitrary: 'Direct source'
+        };
+
+        const currentTrack = queue.currentTrack;
+        const author = currentTrack.author ? currentTrack.author : 'Unknown';
+        if (author === 'cdn.discordapp.com') {
+            author = 'Unknown';
+        }
+        const plays = currentTrack.views !== 0 ? currentTrack.views : 'Unknown';
+        const source =
+            sourceStringsFormatted[currentTrack.raw.source] ?? 'Unknown';
+        const queueLength = queue.tracks.data.length;
+        const timestamp = queue.node.getTimestamp();
+        let bar = `\`${
+            timestamp.current.label
+        }\` ${queue.node.createProgressBar({
+            queue: false,
+            length: progressBarOptions.length ?? 12,
+            timecodes: progressBarOptions.timecodes ?? false,
+            indicator: progressBarOptions.indicator ?? '🔘',
+            leftChar: progressBarOptions.leftChar ?? '▬',
+            rightChar: progressBarOptions.rightChar ?? '▬'
+        })} \`${timestamp.total.label}\``;
+
+        if (
+            currentTrack.raw.duration === 0 ||
+            currentTrack.duration === '0:00'
+        ) {
+            bar = 'No duration available.';
+        }
+
+        const nowPlayingActionRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('nowplaying-skip')
+                .setLabel('Skip track')
+                .setStyle('Secondary')
+        );
+
+        const response = await interaction.editReply({
+            embeds: [
+                new EmbedBuilder()
+                    .setAuthor({
+                        name: interaction.guild.name,
+                        iconURL: interaction.guild.iconURL()
+                    })
+                    .setDescription(
+                        (queue.node.isPaused()
+                            ? `**Currently Paused**\n`
+                            : `**Now Playing**\n`) +
+                            (currentTrack
+                                ? `**[${currentTrack.title}](${currentTrack.url})**`
+                                : 'None') +
+                            `\nRequested by: <@${currentTrack.requestedBy.id}>` +
+                            `\n ${bar}\n\n`
+                    )
+                    .addFields(
+                        {
+                            name: '**Author**',
+                            value: author,
+                            inline: true
+                        },
+                        {
+                            name: '**Plays**',
+                            value: plays.toLocaleString('en-US'),
+                            inline: true
+                        },
+                        {
+                            name: '**Audio source**',
+                            value: `[${source}](${currentTrack.url})`,
+                            inline: true
+                        }
+                    )
+                    .setFooter({
+                        text: queueLength
+                            ? `${queueLength} other tracks in the queue...`
+                            : ' '
+                    })
+                    .setThumbnail(queue.currentTrack.thumbnail)
+                    .setColor(embedColors.colorSuccess)
+            ],
+            components: [nowPlayingActionRow]
+        });
+
+        const collectorFilter = (i) => i.user.id === interaction.user.id;
+        try {
+            const confirmation = await response.awaitMessageComponent({
+                filter: collectorFilter,
+                time: 60000
+            });
+
+            confirmation.deferUpdate();
+
+            if (confirmation.customId === 'nowplaying-skip') {
+                if (
+                    !queue ||
+                    (queue.tracks.data.length === 0 && !queue.currentTrack)
+                ) {
+                    return await interaction.followUp({
+                        embeds: [
+                            new EmbedBuilder()
+                                .setDescription(
+                                    `**Failed**\nThere are no tracks in the queue and nothing currently playing.`
+                                )
+                                .setColor(embedColors.colorWarning)
+                        ],
+                        components: []
+                    });
+                }
+
+                if (queue.currentTrack !== currentTrack) {
+                    return await interaction.followUp({
+                        embeds: [
+                            new EmbedBuilder()
+                                .setDescription(
+                                    `**Failed to skip**\nThis track has already been skipped, or is no longer playing.`
+                                )
+                                .setColor(embedColors.colorWarning)
+                        ],
+                        components: []
+                    });
+                }
+
+                const skippedTrack = queue.currentTrack;
+                let durationFormat =
+                    skippedTrack.raw.duration === 0 ||
+                    skippedTrack.duration === '0:00'
+                        ? ''
+                        : `\`${skippedTrack.duration}\``;
+                queue.node.skip();
+
+                return await interaction.followUp({
+                    embeds: [
+                        new EmbedBuilder()
+                            .setAuthor({
+                                name: interaction.user.username,
+                                iconURL: interaction.user.avatarURL()
+                            })
+                            .setDescription(
+                                `**Skipped track**\n${durationFormat} **[${skippedTrack.title}](${skippedTrack.url})**.`
+                            )
+                            .setThumbnail(skippedTrack.thumbnail)
+                            .setColor(embedColors.colorSuccess)
+                    ],
+                    components: []
+                });
+            }
+        } catch (e) {
+            if (e.code === 'InteractionCollectorError') {
+                return;
+            }
+
+            throw e;
+        }
+    }
+};

--- a/commands/play.js
+++ b/commands/play.js
@@ -105,7 +105,7 @@ module.exports = {
         let durationFormat =
             track.raw.duration === 0 || track.duration === '0:00'
                 ? ''
-                : `\`[${track.duration}]\``;
+                : `\`${track.duration}\``;
 
         if (searchResult.playlist && searchResult.tracks.length > 1) {
             return await interaction.editReply({

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { useQueue } = require('discord-player');
 const { EmbedBuilder } = require('discord.js');
-const { embedColors } = require('../config.json');
+const { embedColors, progressBarOptions } = require('../config.json');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -71,7 +71,7 @@ module.exports = {
                     let durationFormat =
                         track.raw.duration === 0 || track.duration === '0:00'
                             ? ''
-                            : `\`[${track.duration}]\``;
+                            : `\`${track.duration}\``;
 
                     return `**${page * 10 + index + 1}.** ${durationFormat} [${
                         track.title
@@ -98,10 +98,17 @@ module.exports = {
                 ]
             });
         } else {
-            let bar = queue.node.createProgressBar({
+            const timestamp = queue.node.getTimestamp();
+            let bar = `\`${
+                timestamp.current.label
+            }\` ${queue.node.createProgressBar({
                 queue: false,
-                length: 13
-            });
+                length: progressBarOptions.length ?? 12,
+                timecodes: progressBarOptions.timecodes ?? false,
+                indicator: progressBarOptions.indicator ?? '🔘',
+                leftChar: progressBarOptions.leftChar ?? '▬',
+                rightChar: progressBarOptions.rightChar ?? '▬'
+            })} \`${timestamp.total.label}\``;
 
             if (
                 currentTrack.raw.duration === 0 ||

--- a/commands/skip.js
+++ b/commands/skip.js
@@ -57,6 +57,11 @@ module.exports = {
                 });
             } else {
                 const skippedTrack = queue.currentTrack;
+                let durationFormat =
+                skippedTrack.raw.duration === 0 ||
+                skippedTrack.duration === '0:00'
+                    ? ''
+                    : `\`${skippedTrack.duration}\``;
                 queue.node.skipTo(skipToTrack - 1);
 
                 return await interaction.editReply({
@@ -67,7 +72,7 @@ module.exports = {
                                 iconURL: interaction.user.avatarURL()
                             })
                             .setDescription(
-                                `**Skipped**\n**[${skippedTrack.title}](${skippedTrack.url})**.`
+                                `**Skipped track**\n${durationFormat} **[${skippedTrack.title}](${skippedTrack.url})**.`
                             )
                             .setThumbnail(skippedTrack.thumbnail)
                             .setColor(embedColors.colorSuccess)
@@ -88,6 +93,11 @@ module.exports = {
             }
 
             const skippedTrack = queue.currentTrack;
+            let durationFormat =
+                skippedTrack.raw.duration === 0 ||
+                skippedTrack.duration === '0:00'
+                    ? ''
+                    : `\`${skippedTrack.duration}\``;
             queue.node.skip();
 
             return await interaction.editReply({
@@ -98,7 +108,7 @@ module.exports = {
                             iconURL: interaction.user.avatarURL()
                         })
                         .setDescription(
-                            `**Skipped**\n**[${skippedTrack.title}](${skippedTrack.url})**.`
+                            `**Skipped track**\n${durationFormat} **[${skippedTrack.title}](${skippedTrack.url})**.`
                         )
                         .setThumbnail(skippedTrack.thumbnail)
                         .setColor(embedColors.colorSuccess)

--- a/config.json.example
+++ b/config.json.example
@@ -21,7 +21,7 @@
         "maxHistorySize": 100
     },
     "progressBarOptions": {
-        "length": 10,
+        "length": 12,
         "timecodes": false,
         "separator": "┃",
         "indicator": "🔘",

--- a/config.json.example
+++ b/config.json.example
@@ -1,8 +1,7 @@
 {
     "clientId": "Your bot Application ID here.",
     "token": "Your bot auth token here.",
-    "systemServerGuildId": "Your Discord Server ID for system commands here.",
-    "botOwnerClientId": "Your own Discord user ID to access system commands here.",
+    "systemServerGuildIds": ["Server id where system commands can be used", "Another server id where system commands can be used"],
     "embedColors": {
         "colorSuccess": "#23A55A",
         "colorWarning": "#F0B232",
@@ -20,6 +19,14 @@
         "defaultVolume": 50,
         "maxQueueSize": 1000,
         "maxHistorySize": 100
+    },
+    "progressBarOptions": {
+        "length": 10,
+        "timecodes": false,
+        "separator": "┃",
+        "indicator": "🔘",
+        "leftChar": "▬",
+        "rightChar": "▬"
     },
     "minimumLogLevel": "debug",
     "minimumLogLevelConsole": "info",

--- a/deploy-system-commands.js
+++ b/deploy-system-commands.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
 const logger = require('./services/logger.js');
 const { REST, Routes } = require('discord.js');
-const { token, clientId, systemServerGuildId } = require('./config.json');
+const { token, clientId, systemServerGuildIds } = require('./config.json');
 
 const systemCommands = [];
 const systemCommandFiles = fs
@@ -27,12 +27,14 @@ const rest = new REST({ version: '10' }).setToken(token);
 
         logger.info('Started refreshing application (/) system commands.');
 
-        await rest.put(
-            Routes.applicationGuildCommands(clientId, systemServerGuildId),
-            {
-                body: systemCommands
-            }
-        );
+        for (const systemServerGuildId of systemServerGuildIds) {
+            await rest.put(
+                Routes.applicationGuildCommands(clientId, systemServerGuildId),
+                {
+                    body: systemCommands
+                }
+            );
+        }
 
         logger.info('Successfully refreshed application (/) system commands.');
     } catch (error) {

--- a/index.js
+++ b/index.js
@@ -124,8 +124,12 @@ client.on('interactionCreate', async (interaction) => {
         const executionTime = outputTime - inputTime;
 
         if (executionTime > 20000) {
-            // don't send warning message for filters command, as collector timeout happens after 60 seconds
-            if (command.name === 'filters' && executionTime > 55000) {
+            // don't send warning message for commands with collector timeouts, as collector timeout happens after 60 seconds
+            if (
+                (interaction.commandName === 'filters' ||
+                    interaction.commandName === 'nowplaying') &&
+                executionTime > 55000
+            ) {
                 logger.info(
                     `(${interaction.guild.memberCount}) ${interaction.guild.name}> Command '${interaction}' executed in ${executionTime} ms.`
                 );
@@ -139,7 +143,7 @@ client.on('interactionCreate', async (interaction) => {
             // todo: using interaction.editReply() might lead to "unknown interaction" error
             // it might already have been replied to or deferred
             // solution might be to use interaction.followUp() instead or send a message to the channel?
-            return await interaction.editReply({
+            return await interaction.followUp({
                 embeds: [
                     new EmbedBuilder()
                         .setDescription(
@@ -164,7 +168,7 @@ client.on('interactionCreate', async (interaction) => {
         // todo: using interaction.editReply() might lead to "unknown interaction" error
         // it might already have been replied to or deferred
         // solution might be to use interaction.followUp() instead or send a message to the channel?
-        await interaction.editReply({
+        await interaction.followUp({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(

--- a/system-commands/guilds.js
+++ b/system-commands/guilds.js
@@ -1,20 +1,13 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { EmbedBuilder } = require('discord.js');
-const {
-    embedColors,
-    systemServerGuildId,
-    botOwnerClientId
-} = require('../config.json');
+const { embedColors, systemServerGuildIds } = require('../config.json');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('guilds')
         .setDescription('Show list of guilds where bot is added.'),
     run: async ({ interaction, client }) => {
-        if (
-            interaction.guildId !== systemServerGuildId ||
-            interaction.user.id !== botOwnerClientId
-        ) {
+        if (!systemServerGuildIds.includes(interaction.guildId)) {
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()

--- a/system-commands/status.js
+++ b/system-commands/status.js
@@ -1,21 +1,14 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
-const {
-    embedColors,
-    systemServerGuildId,
-    botOwnerClientId
-} = require('../config.json');
+const { embedColors, systemServerGuildIds } = require('../config.json');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('status')
         .setDescription('Show bot status.'),
     run: async ({ interaction, client }) => {
-        if (
-            interaction.guildId !== systemServerGuildId ||
-            interaction.user.id !== botOwnerClientId
-        ) {
+        if (!systemServerGuildIds.includes(interaction.guildId)) {
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()


### PR DESCRIPTION
- Update system commands to not be restricted by bot owner client id.
- System commands can now be executed in several guild ids specified in `config.json`.
- Update duration format in messages sent to user, from `[0:00]` to `0:00`.
- Update progress bar styling, and set progress bar styling options configurable in `config.json`.
- Fixed execution time warnings, and changing to .followUp instead of .editReply.
- Properly defer confirmation on filters command.
- Added `/nowplaying` command showing the currently playing track, with additional data now show in `/queue` command. Also has interactive skip button.