### PR TITLE
Show channel name in queue

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,7 @@
                 "ignoreComments": true
             }
         ],
-        "curly": ["error", "all"]
+        "curly": ["error", "all"],
+        "no-console": ["error"]
     }
 }

--- a/commands/nowplaying.js
+++ b/commands/nowplaying.js
@@ -93,7 +93,9 @@ module.exports = {
             embeds: [
                 new EmbedBuilder()
                     .setAuthor({
-                        name: interaction.guild.name,
+                        name: `Channel: ${queue.channel.name} (${
+                            queue.channel.bitrate / 1000
+                        }kbps)`,
                         iconURL: interaction.guild.iconURL()
                     })
                     .setDescription(

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -88,7 +88,9 @@ module.exports = {
                 embeds: [
                     new EmbedBuilder()
                         .setAuthor({
-                            name: interaction.guild.name,
+                            name: `Channel: ${queue.channel.name} (${
+                                queue.channel.bitrate / 1000
+                            }kbps)`,
                             iconURL: interaction.guild.iconURL()
                         })
                         .setDescription(`**Queue**\n${queueString}`)
@@ -122,7 +124,9 @@ module.exports = {
                 embeds: [
                     new EmbedBuilder()
                         .setAuthor({
-                            name: interaction.guild.name,
+                            name: `Channel: ${queue.channel.name} (${
+                                queue.channel.bitrate / 1000
+                            }kbps)`,
                             iconURL: interaction.guild.iconURL()
                         })
                         .setDescription(


### PR DESCRIPTION
## Changes
- Show connected channel name and bitrate instead of server name in `/queue` and `/nowplaying`.
- Enforce no console logging statements (`console.log()`, `console.error()`, etc.) with eslint.

### Dependencies
No changes.
