### PR TITLE
Feat: Remove pino-pretty as dependency, logger will by default write json to console.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "dotenv": "^16.3.1",
                 "node-os-utils": "^1.3.7",
                 "pino": "^8.14.1",
-                "pino-pretty": "^10.0.1",
                 "yt-stream": "^1.4.8"
             },
             "devDependencies": {
@@ -872,11 +871,6 @@
                 "color-support": "bin.js"
             }
         },
-        "node_modules/colorette": {
-            "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
-        },
         "node_modules/common-tags": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -934,14 +928,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/dateformat": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-            "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/debug": {
@@ -1125,14 +1111,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
-        "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
         "node_modules/entities": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -1315,11 +1293,6 @@
                 "node": ">=0.8.x"
             }
         },
-        "node_modules/fast-copy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
-            "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1372,11 +1345,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         },
         "node_modules/fastq": {
             "version": "1.15.0",
@@ -1632,52 +1600,6 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/help-me": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
-            "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
-            "dependencies": {
-                "glob": "^8.0.0",
-                "readable-stream": "^3.6.0"
-            }
-        },
-        "node_modules/help-me/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/help-me/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/help-me/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/himalaya": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/himalaya/-/himalaya-1.1.0.tgz",
@@ -1841,14 +1763,6 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
-        },
-        "node_modules/joycon": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
@@ -2082,14 +1996,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/minipass": {
@@ -2426,45 +2332,6 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-        "node_modules/pino-pretty": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.0.1.tgz",
-            "integrity": "sha512-yrn00+jNpkvZX/NrPVCPIVHAfTDy3ahF0PND9tKqZk4j9s+loK8dpzrJj4dGb7i+WLuR50ussuTAiWoMWU+qeA==",
-            "dependencies": {
-                "colorette": "^2.0.7",
-                "dateformat": "^4.6.3",
-                "fast-copy": "^3.0.0",
-                "fast-safe-stringify": "^2.1.1",
-                "help-me": "^4.0.1",
-                "joycon": "^3.1.1",
-                "minimist": "^1.2.6",
-                "on-exit-leak-free": "^2.1.0",
-                "pino-abstract-transport": "^1.0.0",
-                "pump": "^3.0.0",
-                "readable-stream": "^4.0.0",
-                "secure-json-parse": "^2.4.0",
-                "sonic-boom": "^3.0.0",
-                "strip-json-comments": "^3.1.1"
-            },
-            "bin": {
-                "pino-pretty": "bin.js"
-            }
-        },
-        "node_modules/pino-pretty/node_modules/readable-stream": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-            "dependencies": {
-                "abort-controller": "^3.0.0",
-                "buffer": "^6.0.3",
-                "events": "^3.3.0",
-                "process": "^0.11.10",
-                "string_decoder": "^1.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
         "node_modules/pino-std-serializers": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
@@ -2602,15 +2469,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
             "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
-        },
-        "node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
         },
         "node_modules/punycode": {
             "version": "2.3.0",
@@ -2779,11 +2637,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/secure-json-parse": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-            "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
-        },
         "node_modules/semver": {
             "version": "7.5.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
@@ -2926,6 +2779,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "dotenv": "^16.3.1",
         "node-os-utils": "^1.3.7",
         "pino": "^8.14.1",
-        "pino-pretty": "^10.0.1",
         "yt-stream": "^1.4.8"
     },
     "devDependencies": {

--- a/services/logger.js
+++ b/services/logger.js
@@ -24,8 +24,11 @@ const transport = pino.transport({
             options: { destination: './app-error.log' }
         },
         {
+            target: 'pino/file',
             level: process.env.MINIMUM_LOG_LEVEL_CONSOLE,
-            target: 'pino-pretty'
+            options: {
+                colorize: true
+            }
         }
     ]
 });


### PR DESCRIPTION
## Changes
- Remove pino-pretty as dependency, logger will by default write json to console.  You can instead pipe output to `pino-pretty` to get formatted output in console, e.g. `tail -f app-info.log | pino-pretty`.

### Dependencies
- Removed `pino-pretty` as dependency, and updated logging service to output raw json to console.
