### PR TITLE
fix: Add buffering to pino async logging

### DIFF
--- a/services/logger.js
+++ b/services/logger.js
@@ -6,28 +6,35 @@ const transport = pino.transport({
         {
             target: 'pino/file',
             level: process.env.MINIMUM_LOG_LEVEL,
-            options: { destination: './app-all.log' }
-        },
-        {
-            target: 'pino/file',
-            level: 'debug',
-            options: { destination: './app-debug.log' }
+            options: {
+                destination: './app-all.log',
+                sync: false,
+                minLength: 4096
+            }
         },
         {
             target: 'pino/file',
             level: 'info',
-            options: { destination: './app-info.log' }
+            options: {
+                destination: './app-info.log',
+                sync: false,
+                minLength: 4096
+            }
         },
         {
             target: 'pino/file',
             level: 'error',
-            options: { destination: './app-error.log' }
+            options: {
+                destination: './app-error.log',
+                sync: false
+            }
         },
         {
             target: 'pino/file',
             level: process.env.MINIMUM_LOG_LEVEL_CONSOLE,
             options: {
-                colorize: true
+                colorize: true,
+                sync: false
             }
         }
     ]


### PR DESCRIPTION
## Changes
- Removed redundant pino transporter for logging debug log level, instead only have `app-all.log`.
- Ensure transports are asynchronous.
- Add minimum buffering of 4096 characters before writing/appending logs to file.

### Dependencies
No changes.
