### PR TITLE
Install mediaplex and dev extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
             "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
-                "@discord-player/extractor": "^4.4.0",
+                "@discord-player/extractor": "^4.4.1-dev.0",
                 "@discordjs/opus": "^0.9.0",
                 "@discordjs/rest": "^1.7.1",
                 "@discordjs/voice": "^0.16.0",
                 "discord-player": "^6.6.1",
                 "discord.js": "^14.11.0",
                 "dotenv": "^16.3.1",
+                "mediaplex": "^0.0.0",
                 "node-os-utils": "^1.3.7",
                 "pino": "^8.14.1",
                 "yt-stream": "^1.4.8"
@@ -40,9 +41,9 @@
             "integrity": "sha512-U86em1cMtopXVuKFDxP8J2DcNOqwCAsYQ2tkzPoJvchsrezcI2cgvN3jtGt9FFECP3pLvSz96ZB9FOHZKG5Mqg=="
         },
         "node_modules/@discord-player/extractor": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@discord-player/extractor/-/extractor-4.4.0.tgz",
-            "integrity": "sha512-TpHZk6ZFS5ot504iVAfnaJrGe2xv9yMauI+2zNLCmAYPeFe6YUbliXrSRoOmKoZi5n1ahkP2VurbmBhqKqEVkw==",
+            "version": "4.4.1-dev.0",
+            "resolved": "https://registry.npmjs.org/@discord-player/extractor/-/extractor-4.4.1-dev.0.tgz",
+            "integrity": "sha512-DVc4B9wGi3OD8rF/s5r+SF+PQAXqIhyuKGQHs/bgKvdrcBiyP7Tqxr3hlcGt/ZtCifiW9Fp77uT7iRkl4gTsWA==",
             "dependencies": {
                 "file-type": "^16.5.4",
                 "genius-lyrics": "^4.4.3",
@@ -1961,6 +1962,237 @@
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "bin": {
                 "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/mediaplex": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex/-/mediaplex-0.0.0.tgz",
+            "integrity": "sha512-pFg3SEQakC49Vem1vlUMptBDB5eiWH0v0jvR35oChtucjAtk3pKEqK0DqiQLShzLVvEnGfqXFIqYP+buFqkw5Q==",
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "mediaplex-android-arm-eabi": "0.0.0",
+                "mediaplex-android-arm64": "0.0.0",
+                "mediaplex-darwin-arm64": "0.0.0",
+                "mediaplex-darwin-universal": "0.0.0",
+                "mediaplex-darwin-x64": "0.0.0",
+                "mediaplex-freebsd-x64": "0.0.0",
+                "mediaplex-linux-arm-gnueabihf": "0.0.0",
+                "mediaplex-linux-arm64-gnu": "0.0.0",
+                "mediaplex-linux-arm64-musl": "0.0.0",
+                "mediaplex-linux-x64-gnu": "0.0.0",
+                "mediaplex-linux-x64-musl": "0.0.0",
+                "mediaplex-win32-arm64-msvc": "0.0.0",
+                "mediaplex-win32-ia32-msvc": "0.0.0",
+                "mediaplex-win32-x64-msvc": "0.0.0"
+            }
+        },
+        "node_modules/mediaplex-android-arm-eabi": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-android-arm-eabi/-/mediaplex-android-arm-eabi-0.0.0.tgz",
+            "integrity": "sha512-cG/Iqebd0CNhf6JcFIejW3VKnYtstm36H73E46UNIemlm8/UOUW1ag8kzhC/4OlgLTThCdwfQG5LIqVI5rqxkA==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-android-arm64": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-android-arm64/-/mediaplex-android-arm64-0.0.0.tgz",
+            "integrity": "sha512-G9K6UPjetZAYNBrQ7ePLNGsyVnbuN90lC7m2Lcd8e2RVd0kxXlzXbSvT4NhnNgP4qEz6XrEzR1daJoHyIHf/Rw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-darwin-arm64": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-darwin-arm64/-/mediaplex-darwin-arm64-0.0.0.tgz",
+            "integrity": "sha512-TgzMVcx7P0cfRxqf2icC4KkFJg9PCnzwljBPWoxAvZLHktrod7BJTWj0UA065L3IedHBBQqzAq3XLH/4+ZFHPg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-darwin-universal": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-darwin-universal/-/mediaplex-darwin-universal-0.0.0.tgz",
+            "integrity": "sha512-avLsD2J8HrYv7hgHMFVUSekgr9GMEp31cG57HlfhSF/jPZlZXj70pb0YHE0SW9/CG44eVIdZsSSC8XmWB8iCug==",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-darwin-x64": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-darwin-x64/-/mediaplex-darwin-x64-0.0.0.tgz",
+            "integrity": "sha512-JUcgCkXE2fmFo6U6RPs2koRH5XKKRtiP1irnGBuB5282DhSoB90Mb8ZdluOLQYpsAEBSDtcqkLWNoyl56Gbp7Q==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-freebsd-x64": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-freebsd-x64/-/mediaplex-freebsd-x64-0.0.0.tgz",
+            "integrity": "sha512-U10wDBUs2KiVByMZ1VX+QAruNPgABQI+AMZJnb5hIYcqrWM8r9/1IdPzn3jWK6gApUYMLFDJmYGh01YLaycUiQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-linux-arm-gnueabihf": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-linux-arm-gnueabihf/-/mediaplex-linux-arm-gnueabihf-0.0.0.tgz",
+            "integrity": "sha512-f1gIHlbWE9/0Qt5GEvY2Vwgqo4k7iNWmZkI2XmLApX/QJ4OVU1UFGG0HyY8rVXQd5iLuxbtPwxkLBWSW+eIkXg==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-linux-arm64-gnu": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-linux-arm64-gnu/-/mediaplex-linux-arm64-gnu-0.0.0.tgz",
+            "integrity": "sha512-Gr+Dw9ObUkg0U3uckTJkn19kxs+LHhcSgM3v92gDCXBFu2JzkidoRzpwYRzVtSuHgjBQQfv+EU3JgszzI9UWEg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-linux-arm64-musl": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-linux-arm64-musl/-/mediaplex-linux-arm64-musl-0.0.0.tgz",
+            "integrity": "sha512-SRajRO2bXudnYICFpFAr3J/OKrWMDi7RRHn90RcfLkUnE3JsiwQHeKJhW6gDj3SPcgBODMgfR5BrpMkLGRmaJQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-linux-x64-gnu": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-linux-x64-gnu/-/mediaplex-linux-x64-gnu-0.0.0.tgz",
+            "integrity": "sha512-RbfMUCknCBCJv73HiyWV+nMeLCAvTMn/xlaV2vbhtTYFAWAheOvW4lSzfkBZbeZ4LSeiRnCv+5GOMAtesRgVnw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-linux-x64-musl": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-linux-x64-musl/-/mediaplex-linux-x64-musl-0.0.0.tgz",
+            "integrity": "sha512-GBxA3j+2bdzZAhVtR4QPUhoULMNwfHwNvgyycZS8vmpjLcDGXieEBCc72eFGHOzNFLzzJ0BvEO8R4R/rZ5VzXg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-win32-arm64-msvc": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-win32-arm64-msvc/-/mediaplex-win32-arm64-msvc-0.0.0.tgz",
+            "integrity": "sha512-7CkVgz2N47VcLIffEVqdCgBvuUOGE/qNOhAY13Qp/qlbNHlhPLKPiRg8mwZaJ0Js5dsJRqXWZ8+u47PD6twA3A==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-win32-ia32-msvc": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-win32-ia32-msvc/-/mediaplex-win32-ia32-msvc-0.0.0.tgz",
+            "integrity": "sha512-6WbRf8RJ3isEbCjgnc0Z+4w3q+1sAEFQO6vU4ucBpiWWxHIRKUP3ykiVAobAoGw9nsG8UUmDbPliWL0RFcVzDg==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/mediaplex-win32-x64-msvc": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/mediaplex-win32-x64-msvc/-/mediaplex-win32-x64-msvc-0.0.0.tgz",
+            "integrity": "sha512-Uc7L7b2yeHGmFQ+kRz2F3Dr36/xI/H00LUERwmLOVRaac8rMLhvPhWBpxVmwLMD11wGGnYMtbZLuzROtBMZunw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -26,13 +26,14 @@
         "eslint": "eslint ./"
     },
     "dependencies": {
-        "@discord-player/extractor": "^4.4.0",
+        "@discord-player/extractor": "^4.4.1-dev.0",
         "@discordjs/opus": "^0.9.0",
         "@discordjs/rest": "^1.7.1",
         "@discordjs/voice": "^0.16.0",
         "discord-player": "^6.6.1",
         "discord.js": "^14.11.0",
         "dotenv": "^16.3.1",
+        "mediaplex": "^0.0.0",
         "node-os-utils": "^1.3.7",
         "pino": "^8.14.1",
         "yt-stream": "^1.4.8"


### PR DESCRIPTION
## Changes
- Added `mediaplex` as dependency. This will add support for extracting ID3 info from mp3 files, and possibly more later.
- Updated dependency `@discord-player/extractor` to dev version `^4.4.1-dev.0`, this will allow using `mediaplex` for retrieving duration from mp3 tracks.

### Dependencies
- Added `mediaplex` and update `@discord-player/extractor` to dev version `^4.4.1-dev.0`. See notes above under changes.