### PR TITLE
feat: Updated /help command to be dynamic

### DIFF
--- a/src/commands/info/help.js
+++ b/src/commands/info/help.js
@@ -5,8 +5,40 @@ module.exports = {
     data: new SlashCommandBuilder()
         .setName('help')
         .setDescription('Show a list of commands and their usage.')
-        .setDMPermission(false),
-    execute: async ({ interaction }) => {
+        .setDMPermission(false)
+        .setNSFW(false),
+    execute: async ({ interaction, client }) => {
+        const commandList = client.commands
+            .filter((command) => {
+                // don't include system commands
+                if (command.isSystemCommand) {
+                    return false;
+                }
+                return true;
+            })
+            .map((command) => {
+                let params = command.data.options[0] ? `**\`${command.data.options[0].name}\`**` + ' ' : '';
+                let beta = command.isBeta ? `${embedOptions.icons.beta} ` : '';
+                let newCommand = command.isNew ? `${embedOptions.icons.new} ` : '';
+                return `- **\`/${command.data.name}\`** ${params}- ${beta}${newCommand}${command.data.description}`;
+            });
+
+        const commandListString = commandList.join('\n');
+
+        return await interaction.editReply({
+            embeds: [
+                new EmbedBuilder()
+                    .setDescription(
+                        `${embedOptions.icons.rule} **List of commands**\n` +
+                            `${commandListString}\n\n` +
+                            `${embedOptions.icons.support} **Support server**\nJoin the support server for help or suggestions: \n**${botOptions.serverInviteUrl}**\n\n` +
+                            `${embedOptions.icons.bot} **Enjoying ${botOptions.name}?**\nAdd me to another server: \n**[Click me!](${botOptions.botInviteUrl})**`
+                    )
+                    .setColor(embedOptions.colors.info)
+            ]
+        });
+
+        /*
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
@@ -30,5 +62,6 @@ module.exports = {
                     .setColor(embedOptions.colors.info)
             ]
         });
+        */
     }
 };

--- a/src/commands/player/filters.js
+++ b/src/commands/player/filters.js
@@ -13,10 +13,13 @@ const {
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: true,
     data: new SlashCommandBuilder()
         .setName('filters')
         .setDescription('Toggle various audio filters during playback.')
-        .setDMPermission(false),
+        .setDMPermission(false)
+        .setNSFW(false),
     execute: async ({ interaction }) => {
         if (await notInVoiceChannel(interaction)) {
             return;

--- a/src/commands/player/leave.js
+++ b/src/commands/player/leave.js
@@ -5,12 +5,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('leave')
         .setDescription('Clear the track queue and remove the bot from voice channel.')
-        .setDMPermission(false),
-
-    // todo, allow command to be executed if bot is only member in voice channel
+        .setDMPermission(false)
+        .setNSFW(false),
     execute: async ({ interaction }) => {
         if (await notInVoiceChannel(interaction)) {
             return;

--- a/src/commands/player/loop.js
+++ b/src/commands/player/loop.js
@@ -6,10 +6,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: true,
     data: new SlashCommandBuilder()
         .setName('loop')
         .setDescription('Toggle looping a track, the whole queue or autoplay.')
         .setDMPermission(false)
+        .setNSFW(false)
         .addStringOption((option) =>
             option
                 .setName('mode')

--- a/src/commands/player/nowplaying.js
+++ b/src/commands/player/nowplaying.js
@@ -6,10 +6,13 @@ const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder } = r
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('nowplaying')
         .setDescription('Show information about the track currently playing.')
-        .setDMPermission(false),
+        .setDMPermission(false)
+        .setNSFW(false),
     execute: async ({ interaction }) => {
         if (await notInVoiceChannel(interaction)) {
             return;

--- a/src/commands/player/pause.js
+++ b/src/commands/player/pause.js
@@ -6,10 +6,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('pause')
         .setDescription('Pause or resume the current track.')
-        .setDMPermission(false),
+        .setDMPermission(false)
+        .setNSFW(false),
     execute: async ({ interaction }) => {
         if (await notInVoiceChannel(interaction)) {
             return;

--- a/src/commands/player/play.js
+++ b/src/commands/player/play.js
@@ -7,10 +7,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useMainPlayer, useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('play')
         .setDescription('Add a track or playlist to the queue by searching or url.')
         .setDMPermission(false)
+        .setNSFW(false)
         .addStringOption((option) =>
             option
                 .setName('query')

--- a/src/commands/player/queue.js
+++ b/src/commands/player/queue.js
@@ -5,10 +5,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('queue')
         .setDescription('Show the list of tracks added to the queue.')
         .setDMPermission(false)
+        .setNSFW(false)
         .addNumberOption((option) => option.setName('page').setDescription('Page number of the queue').setMinValue(1)),
     execute: async ({ interaction }) => {
         if (await notInVoiceChannel(interaction)) {

--- a/src/commands/player/remove.js
+++ b/src/commands/player/remove.js
@@ -6,10 +6,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('remove')
         .setDescription('Remove a specific track from the queue.')
         .setDMPermission(false)
+        .setNSFW(false)
         .addNumberOption((option) =>
             option
                 .setName('tracknumber')

--- a/src/commands/player/seek.js
+++ b/src/commands/player/seek.js
@@ -6,10 +6,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('seek')
         .setDescription('Seek to a specified duration in the current track.')
         .setDMPermission(false)
+        .setNSFW(false)
         .addStringOption((option) =>
             option
                 .setName('duration')

--- a/src/commands/player/skip.js
+++ b/src/commands/player/skip.js
@@ -6,10 +6,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('skip')
         .setDescription('Skip current or specified track.')
         .setDMPermission(false)
+        .setNSFW(false)
         .addNumberOption((option) =>
             option.setName('tracknumber').setDescription('Track number to skip to in the queue.').setMinValue(1)
         ),

--- a/src/commands/player/stop.js
+++ b/src/commands/player/stop.js
@@ -5,12 +5,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: true,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('stop')
         .setDescription('Stop playing audio and clear the track queue.')
-        .setDMPermission(false),
-
-    // todo, allow command to be executed if bot is only member in voice channel
+        .setDMPermission(false)
+        .setNSFW(false),
     execute: async ({ interaction }) => {
         if (await notInVoiceChannel(interaction)) {
             return;

--- a/src/commands/player/volume.js
+++ b/src/commands/player/volume.js
@@ -6,10 +6,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { useQueue } = require('discord-player');
 
 module.exports = {
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('volume')
         .setDescription('Show or set the playback volume for tracks.')
         .setDMPermission(false)
+        .setNSFW(false)
         .addNumberOption((option) =>
             option
                 .setName('percentage')

--- a/src/commands/system/guilds.js
+++ b/src/commands/system/guilds.js
@@ -5,10 +5,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 
 module.exports = {
     isSystemCommand: true,
+    isNew: false,
+    isBeta: false,
     data: new SlashCommandBuilder()
         .setName('guilds')
         .setDescription('Show list of guilds where bot is added.')
-        .setDMPermission(false),
+        .setDMPermission(false)
+        .setNSFW(false),
     execute: async ({ interaction, client }) => {
         if (await notValidGuildId(interaction)) {
             logger.debug(`[Shard ${client.shard.ids[0]}] Not a valid guild id.`);

--- a/src/commands/system/status.js
+++ b/src/commands/system/status.js
@@ -7,7 +7,13 @@ const { version, dependencies } = require('../../../package.json');
 
 module.exports = {
     isSystemCommand: true,
-    data: new SlashCommandBuilder().setName('status').setDescription('Show bot status.').setDMPermission(false),
+    isNew: false,
+    isBeta: false,
+    data: new SlashCommandBuilder()
+        .setName('status')
+        .setDescription('Show bot status.')
+        .setDMPermission(false)
+        .setNSFW(false),
     execute: async ({ interaction, client }) => {
         if (await notValidGuildId(interaction)) {
             return;


### PR DESCRIPTION
## Changes
- Added new fields on commands: `isNew`, `isBeta`.
- `/help` command is now dynamic and fetches info from the commands. Name, description and first argument, e.g. `query` is retrieved. `/help` command is therefore no longer static.
-  Updated commands to set NSFW to false explicitly.

### Dependencies
No changes.