### PR TITLE
Refactoring

### DIFF
--- a/src/classes/interactions.ts
+++ b/src/classes/interactions.ts
@@ -1,4 +1,5 @@
 import config from 'config';
+import { GuildQueue } from 'discord-player';
 import {
     ApplicationCommandOptionChoiceData,
     AutocompleteInteraction,
@@ -64,7 +65,7 @@ abstract class BaseInteractionWithEmbedResponse extends BaseInteraction {
         this.botOptions = config.get('botOptions');
     }
 
-    protected async getEmbedAuthor(
+    protected async getEmbedUserAuthor(
         interaction: MessageComponentInteraction | ChatInputCommandInteraction
     ): Promise<EmbedAuthorOptions> {
         let authorName: string = '';
@@ -77,6 +78,16 @@ abstract class BaseInteractionWithEmbedResponse extends BaseInteraction {
         return {
             name: authorName,
             iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
+        };
+    }
+
+    protected async getEmbedQueueAuthor(
+        interaction: MessageComponentInteraction | ChatInputCommandInteraction,
+        queue: GuildQueue
+    ): Promise<EmbedAuthorOptions> {
+        return {
+            name: `Channel: ${queue.channel!.name} (${queue.channel!.bitrate / 1000}kbps)`,
+            iconURL: interaction.guild!.iconURL() || this.embedOptions.info.fallbackIconUrl
         };
     }
 }

--- a/src/classes/interactions.ts
+++ b/src/classes/interactions.ts
@@ -21,6 +21,7 @@ import {
     BaseSlashCommandParams,
     BaseSlashCommandReturnType
 } from '../types/interactionTypes';
+import { ValidatorParams } from '../types/utilTypes';
 
 abstract class BaseInteraction {
     protected getLoggerBase(
@@ -36,6 +37,16 @@ abstract class BaseInteraction {
             shardId: interaction.guild?.shardId,
             guildId: interaction.guild?.id
         });
+    }
+
+    protected validators: ((args: ValidatorParams) => Promise<boolean>)[] = [];
+
+    protected async runValidators(args: ValidatorParams): Promise<void> {
+        for (const validator of this.validators) {
+            if (await validator(args)) {
+                return Promise.reject();
+            }
+        }
     }
 
     abstract execute(

--- a/src/classes/interactions.ts
+++ b/src/classes/interactions.ts
@@ -6,7 +6,8 @@ import {
     Interaction,
     Message,
     MessageComponentInteraction,
-    SlashCommandBuilder
+    SlashCommandBuilder,
+    SlashCommandSubcommandsOnlyBuilder
 } from 'discord.js';
 import { Logger } from 'pino';
 import loggerModule from '../services/logger';
@@ -43,7 +44,7 @@ abstract class BaseInteraction {
 }
 
 export abstract class BaseSlashCommandInteraction extends BaseInteraction {
-    data: Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>;
+    data: Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'> | SlashCommandSubcommandsOnlyBuilder;
     isSystemCommand: boolean;
     isNew: boolean;
     isBeta: boolean;
@@ -52,7 +53,7 @@ export abstract class BaseSlashCommandInteraction extends BaseInteraction {
     name: string;
 
     constructor(
-        data: Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>,
+        data: Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'> | SlashCommandSubcommandsOnlyBuilder,
         isSystemCommand: boolean = false,
         isNew: boolean = false,
         isBeta: boolean = false

--- a/src/classes/interactions.ts
+++ b/src/classes/interactions.ts
@@ -3,6 +3,8 @@ import {
     ApplicationCommandOptionChoiceData,
     AutocompleteInteraction,
     ChatInputCommandInteraction,
+    EmbedAuthorOptions,
+    GuildMember,
     Interaction,
     Message,
     MessageComponentInteraction,
@@ -21,7 +23,7 @@ import {
     BaseSlashCommandParams,
     BaseSlashCommandReturnType
 } from '../types/interactionTypes';
-import { ValidatorParams } from '../types/utilTypes';
+import { Validator, ValidatorParams } from '../types/utilTypes';
 
 abstract class BaseInteraction {
     protected getLoggerBase(
@@ -39,13 +41,11 @@ abstract class BaseInteraction {
         });
     }
 
-    protected validators: ((args: ValidatorParams) => Promise<boolean>)[] = [];
+    protected validators: Validator[] = [];
 
-    protected async runValidators(args: ValidatorParams): Promise<void> {
-        for (const validator of this.validators) {
-            if (await validator(args)) {
-                return Promise.reject();
-            }
+    protected async runValidators(args: ValidatorParams, validators?: Validator[]): Promise<void> {
+        for (const validator of validators ? validators : this.validators) {
+            await validator(args);
         }
     }
 
@@ -54,13 +54,38 @@ abstract class BaseInteraction {
     ): Promise<Message<boolean> | ApplicationCommandOptionChoiceData | void>;
 }
 
-export abstract class BaseSlashCommandInteraction extends BaseInteraction {
+abstract class BaseInteractionWithEmbedResponse extends BaseInteraction {
+    embedOptions: EmbedOptions;
+    botOptions: BotOptions;
+
+    constructor() {
+        super();
+        this.embedOptions = config.get('embedOptions');
+        this.botOptions = config.get('botOptions');
+    }
+
+    protected async getEmbedAuthor(
+        interaction: MessageComponentInteraction | ChatInputCommandInteraction
+    ): Promise<EmbedAuthorOptions> {
+        let authorName: string = '';
+        if (interaction.member instanceof GuildMember) {
+            authorName = interaction.member.nickname || interaction.user.username;
+        } else {
+            authorName = interaction.user.username;
+        }
+
+        return {
+            name: authorName,
+            iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
+        };
+    }
+}
+
+export abstract class BaseSlashCommandInteraction extends BaseInteractionWithEmbedResponse {
     data: Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'> | SlashCommandSubcommandsOnlyBuilder;
     isSystemCommand: boolean;
     isNew: boolean;
     isBeta: boolean;
-    embedOptions: EmbedOptions;
-    botOptions: BotOptions;
     name: string;
 
     constructor(
@@ -74,8 +99,6 @@ export abstract class BaseSlashCommandInteraction extends BaseInteraction {
         this.isSystemCommand = isSystemCommand;
         this.isNew = isNew;
         this.isBeta = isBeta;
-        this.embedOptions = config.get('embedOptions');
-        this.botOptions = config.get('botOptions');
         this.name = data.name;
     }
 
@@ -86,22 +109,7 @@ export abstract class BaseSlashCommandInteraction extends BaseInteraction {
     abstract execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType;
 }
 
-export abstract class BaseAutocompleteInteraction extends BaseInteraction {
-    name: string;
-
-    constructor(name: string) {
-        super();
-        this.name = name;
-    }
-
-    protected getLogger(name: string, executionId: string, interaction: AutocompleteInteraction): Logger {
-        return super.getLoggerBase('autocompleteInteraction', name, executionId, interaction);
-    }
-
-    abstract execute(params: BaseAutocompleteParams): BaseAutocompleteReturnType;
-}
-
-export abstract class BaseComponentInteraction extends BaseInteraction {
+export abstract class BaseComponentInteraction extends BaseInteractionWithEmbedResponse {
     embedOptions: EmbedOptions;
     botOptions: BotOptions;
     name: string;
@@ -120,7 +128,29 @@ export abstract class BaseComponentInteraction extends BaseInteraction {
     abstract execute(params: BaseComponentParams): BaseComponentReturnType;
 }
 
+export abstract class BaseAutocompleteInteraction extends BaseInteraction {
+    name: string;
+
+    constructor(name: string) {
+        super();
+        this.name = name;
+    }
+
+    protected getLogger(name: string, executionId: string, interaction: AutocompleteInteraction): Logger {
+        return super.getLoggerBase('autocompleteInteraction', name, executionId, interaction);
+    }
+
+    abstract execute(params: BaseAutocompleteParams): BaseAutocompleteReturnType;
+}
+
 export class CustomError extends Error {
     type?: string;
     code?: string;
+}
+
+export class InteractionValidationError extends Error {
+    constructor(message?: string) {
+        super(message);
+        this.name = 'InteractionValidationError';
+    }
 }

--- a/src/events/client/debug.ts
+++ b/src/events/client/debug.ts
@@ -1,8 +1,7 @@
 import { Events } from 'discord.js';
 import { randomUUID as uuidv4 } from 'node:crypto';
-
-import loggerModule from '../../services/logger';
 import { Logger } from 'pino';
+import loggerModule from '../../services/logger';
 
 module.exports = {
     name: Events.Debug,

--- a/src/events/client/disconnect.ts
+++ b/src/events/client/disconnect.ts
@@ -1,11 +1,10 @@
 import config from 'config';
 import { BaseGuildTextChannel, EmbedBuilder } from 'discord.js';
 import { randomUUID as uuidv4 } from 'node:crypto';
-
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { ExtendedClient } from '../../types/clientTypes';
 import { EmbedOptions, SystemOptions } from '../../types/configTypes';
-import { Logger } from 'pino';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const systemOptions: SystemOptions = config.get('systemOptions');

--- a/src/events/client/error.ts
+++ b/src/events/client/error.ts
@@ -1,8 +1,7 @@
 import { Events } from 'discord.js';
 import { randomUUID as uuidv4 } from 'node:crypto';
-
-import loggerModule from '../../services/logger';
 import { Logger } from 'pino';
+import loggerModule from '../../services/logger';
 
 module.exports = {
     name: Events.Error,

--- a/src/events/client/guildCreate.ts
+++ b/src/events/client/guildCreate.ts
@@ -1,8 +1,7 @@
 import { Events, Guild } from 'discord.js';
 import { randomUUID as uuidv4 } from 'node:crypto';
-
-import loggerModule from '../../services/logger';
 import { Logger } from 'pino';
+import loggerModule from '../../services/logger';
 
 module.exports = {
     name: Events.GuildCreate,

--- a/src/events/client/guildDelete.ts
+++ b/src/events/client/guildDelete.ts
@@ -1,8 +1,7 @@
 import { Events, Guild } from 'discord.js';
 import { randomUUID as uuidv4 } from 'node:crypto';
-
-import loggerModule from '../../services/logger';
 import { Logger } from 'pino';
+import loggerModule from '../../services/logger';
 
 module.exports = {
     name: Events.GuildDelete,

--- a/src/events/client/ready.ts
+++ b/src/events/client/ready.ts
@@ -1,7 +1,6 @@
 import config from 'config';
 import { BaseGuildTextChannel, EmbedBuilder, Events, PresenceData } from 'discord.js';
 import { randomUUID as uuidv4 } from 'node:crypto';
-
 import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { ExtendedClient } from '../../types/clientTypes';

--- a/src/events/client/reconnecting.ts
+++ b/src/events/client/reconnecting.ts
@@ -1,7 +1,6 @@
 import config from 'config';
 import { BaseGuildTextChannel, EmbedBuilder } from 'discord.js';
 import { randomUUID as uuidv4 } from 'node:crypto';
-
 import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { ExtendedClient } from '../../types/clientTypes';

--- a/src/events/client/warn.ts
+++ b/src/events/client/warn.ts
@@ -1,6 +1,6 @@
 import { Events } from 'discord.js';
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 
 module.exports = {

--- a/src/events/interactions/interactionCreate.ts
+++ b/src/events/interactions/interactionCreate.ts
@@ -6,15 +6,15 @@ import {
     InteractionType,
     MessageComponentInteraction
 } from 'discord.js';
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
+import { CustomError } from '../../classes/interactions';
 import { handleAutocomplete } from '../../handlers/interactionAutocompleteHandler';
 import { handleCommand } from '../../handlers/interactionCommandHandler';
 import { handleComponent } from '../../handlers/interactionComponentHandler';
 import { handleError } from '../../handlers/interactionErrorHandler';
 import loggerModule from '../../services/logger';
 import { ExtendedClient } from '../../types/clientTypes';
-import { CustomError } from '../../classes/interactions';
 
 module.exports = {
     name: Events.InteractionCreate,

--- a/src/events/player/generalDebug.ts
+++ b/src/events/player/generalDebug.ts
@@ -1,5 +1,5 @@
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 
 module.exports = {

--- a/src/events/player/generalError.ts
+++ b/src/events/player/generalError.ts
@@ -1,7 +1,7 @@
 import config from 'config';
 import { BaseGuildTextChannel, EmbedBuilder } from 'discord.js';
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { BotOptions, EmbedOptions, SystemOptions } from '../../types/configTypes';
 import { ExtendedGuildQueuePlayerNode } from '../../types/eventTypes';

--- a/src/events/player/playerDebug.ts
+++ b/src/events/player/playerDebug.ts
@@ -1,5 +1,5 @@
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 
 module.exports = {

--- a/src/events/player/playerError.ts
+++ b/src/events/player/playerError.ts
@@ -1,7 +1,7 @@
 import config from 'config';
 import { BaseGuildTextChannel, EmbedBuilder } from 'discord.js';
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { BotOptions, EmbedOptions, SystemOptions } from '../../types/configTypes';
 import { ExtendedGuildQueuePlayerNode } from '../../types/eventTypes';

--- a/src/events/player/playerSkip.ts
+++ b/src/events/player/playerSkip.ts
@@ -1,8 +1,8 @@
 import config from 'config';
 import { Track } from 'discord-player';
 import { BaseGuildTextChannel, EmbedBuilder } from 'discord.js';
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { BotOptions, EmbedOptions, SystemOptions } from '../../types/configTypes';
 import { ExtendedGuildQueuePlayerNode } from '../../types/eventTypes';

--- a/src/events/player/playerStart.ts
+++ b/src/events/player/playerStart.ts
@@ -1,6 +1,6 @@
 import { Track } from 'discord-player';
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { ExtendedGuildQueuePlayerNode } from '../../types/eventTypes';
 

--- a/src/events/process/uncaughtException.ts
+++ b/src/events/process/uncaughtException.ts
@@ -1,5 +1,5 @@
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 
 module.exports = {

--- a/src/events/process/unhandledRejection.ts
+++ b/src/events/process/unhandledRejection.ts
@@ -1,5 +1,5 @@
-import { Logger } from 'pino';
 import { randomUUID as uuidv4 } from 'node:crypto';
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 
 module.exports = {

--- a/src/handlers/interactionAutocompleteHandler.ts
+++ b/src/handlers/interactionAutocompleteHandler.ts
@@ -1,8 +1,8 @@
 import { AutocompleteInteraction } from 'discord.js';
 import { Logger } from 'pino';
+import { BaseAutocompleteInteraction } from '../classes/interactions';
 import loggerModule from '../services/logger';
 import { ExtendedClient } from '../types/clientTypes';
-import { BaseAutocompleteInteraction } from '../classes/interactions';
 
 export const handleAutocomplete = async (
     interaction: AutocompleteInteraction,

--- a/src/handlers/interactionCommandHandler.ts
+++ b/src/handlers/interactionCommandHandler.ts
@@ -1,8 +1,8 @@
 import { ChatInputCommandInteraction } from 'discord.js';
 import { Logger } from 'pino';
+import { BaseSlashCommandInteraction } from '../classes/interactions';
 import loggerModule from '../services/logger';
 import { ExtendedClient } from '../types/clientTypes';
-import { BaseSlashCommandInteraction } from '../classes/interactions';
 import { checkChannelPermissionViewable } from '../utils/validation/permissionValidator';
 
 export const handleCommand = async (

--- a/src/handlers/interactionCommandHandler.ts
+++ b/src/handlers/interactionCommandHandler.ts
@@ -3,7 +3,7 @@ import { Logger } from 'pino';
 import loggerModule from '../services/logger';
 import { ExtendedClient } from '../types/clientTypes';
 import { BaseSlashCommandInteraction } from '../classes/interactions';
-import { cannotSendMessageInChannel } from '../utils/validation/permissionValidator';
+import { checkChannelPermissionViewable } from '../utils/validation/permissionValidator';
 
 export const handleCommand = async (
     interaction: ChatInputCommandInteraction,
@@ -20,9 +20,7 @@ export const handleCommand = async (
     await interaction.deferReply();
     logger.debug('Interaction deferred.');
 
-    if (await cannotSendMessageInChannel({ interaction, executionId })) {
-        return;
-    }
+    await checkChannelPermissionViewable({ interaction, executionId });
 
     const slashCommand: BaseSlashCommandInteraction = client.slashCommandInteractions!.get(
         interactionIdentifier

--- a/src/handlers/interactionComponentHandler.ts
+++ b/src/handlers/interactionComponentHandler.ts
@@ -3,7 +3,7 @@ import { Logger } from 'pino';
 import loggerModule from '../services/logger';
 import { ExtendedClient } from '../types/clientTypes';
 import { BaseComponentInteraction } from '../classes/interactions';
-import { cannotSendMessageInChannel } from '../utils/validation/permissionValidator';
+import { checkChannelPermissionViewable } from '../utils/validation/permissionValidator';
 
 export const handleComponent = async (
     interaction: MessageComponentInteraction,
@@ -25,9 +25,7 @@ export const handleComponent = async (
 
     logger.debug(`Parsed componentId '${componentId}' from identifier '${interactionIdentifier}'.`);
 
-    if (await cannotSendMessageInChannel({ interaction, executionId })) {
-        return;
-    }
+    await checkChannelPermissionViewable({ interaction, executionId });
 
     const component: BaseComponentInteraction = client.componentInteractions!.get(
         componentId

--- a/src/handlers/interactionComponentHandler.ts
+++ b/src/handlers/interactionComponentHandler.ts
@@ -1,8 +1,8 @@
 import { MessageComponentInteraction } from 'discord.js';
 import { Logger } from 'pino';
+import { BaseComponentInteraction } from '../classes/interactions';
 import loggerModule from '../services/logger';
 import { ExtendedClient } from '../types/clientTypes';
-import { BaseComponentInteraction } from '../classes/interactions';
 import { checkChannelPermissionViewable } from '../utils/validation/permissionValidator';
 
 export const handleComponent = async (

--- a/src/handlers/interactionErrorHandler.ts
+++ b/src/handlers/interactionErrorHandler.ts
@@ -8,9 +8,9 @@ import {
     MessageComponentInteraction
 } from 'discord.js';
 import { Logger } from 'pino';
+import { CustomError, InteractionValidationError } from '../classes/interactions';
 import loggerModule from '../services/logger';
 import { BotOptions, EmbedOptions } from '../types/configTypes';
-import { CustomError, InteractionValidationError } from '../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const botOptions: BotOptions = config.get('botOptions');

--- a/src/handlers/interactionErrorHandler.ts
+++ b/src/handlers/interactionErrorHandler.ts
@@ -10,7 +10,7 @@ import {
 import { Logger } from 'pino';
 import loggerModule from '../services/logger';
 import { BotOptions, EmbedOptions } from '../types/configTypes';
-import { CustomError } from '../classes/interactions';
+import { CustomError, InteractionValidationError } from '../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const botOptions: BotOptions = config.get('botOptions');
@@ -27,6 +27,13 @@ export const handleError = async (
         name: 'interactionErrorHandler',
         executionId: executionId
     });
+
+    if (error instanceof InteractionValidationError) {
+        logger.debug(
+            `Interaction validation error '${error.message}' while handling interaction '${interactionIdentifier}'.`
+        );
+        return;
+    }
 
     // TODO: Extract replies for embeds
     const errorReply: InteractionReplyOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
-import 'dotenv/config';
-
 import config from 'config';
 import { Client, Shard, ShardEvents, ShardingManager, ShardingManagerOptions } from 'discord.js';
+import 'dotenv/config';
 import { randomUUID as uuidv4 } from 'node:crypto';
-
 import { Logger } from 'pino';
 import loggerModule from './services/logger';
 

--- a/src/interactions/autocomplete/lyrics.ts
+++ b/src/interactions/autocomplete/lyrics.ts
@@ -1,8 +1,8 @@
 import { LyricsData, lyricsExtractor } from '@discord-player/extractor';
 import { Player, SearchResult, useMainPlayer } from 'discord-player';
 import { ApplicationCommandOptionChoiceData } from 'discord.js';
-import { BaseAutocompleteParams, BaseAutocompleteReturnType } from '../../types/interactionTypes';
 import { BaseAutocompleteInteraction } from '../../classes/interactions';
+import { BaseAutocompleteParams, BaseAutocompleteReturnType } from '../../types/interactionTypes';
 
 // TODO: create type for recent query object
 const recentQueries = new Map();

--- a/src/interactions/autocomplete/play.ts
+++ b/src/interactions/autocomplete/play.ts
@@ -1,7 +1,7 @@
 import { Player, SearchResult, useMainPlayer } from 'discord-player';
 import { ApplicationCommandOptionChoiceData } from 'discord.js';
-import { BaseAutocompleteParams, BaseAutocompleteReturnType } from '../../types/interactionTypes';
 import { BaseAutocompleteInteraction } from '../../classes/interactions';
+import { BaseAutocompleteParams, BaseAutocompleteReturnType } from '../../types/interactionTypes';
 
 // TODO: create type for recent query object
 const recentQueries = new Map();

--- a/src/interactions/commands/info/help.ts
+++ b/src/interactions/commands/info/help.ts
@@ -1,6 +1,6 @@
 import { EmbedBuilder, SlashCommandBuilder, SlashCommandNumberOption, SlashCommandStringOption } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 
 class HelpCommand extends BaseSlashCommandInteraction {
     constructor() {

--- a/src/interactions/commands/info/status.ts
+++ b/src/interactions/commands/info/status.ts
@@ -2,8 +2,8 @@ import { EmbedBuilder, Guild, SlashCommandBuilder } from 'discord.js';
 import osu from 'node-os-utils';
 // @ts-ignore
 import { version } from '../../../../package.json';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { getUptimeFormatted } from '../../../utils/system/getUptimeFormatted';
 
 class StatusCommand extends BaseSlashCommandInteraction {

--- a/src/interactions/commands/player/filters.ts
+++ b/src/interactions/commands/player/filters.ts
@@ -7,15 +7,17 @@ import {
     APIStringSelectComponent,
     ButtonBuilder,
     ButtonStyle,
+    ChatInputCommandInteraction,
     ComponentType,
     EmbedBuilder,
     SlashCommandBuilder,
     StringSelectMenuBuilder,
     StringSelectMenuOptionBuilder
 } from 'discord.js';
+import { Logger } from 'pino';
+import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { FFmpegFilterOption, FFmpegFilterOptions } from '../../../types/configTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
-import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { queueDoesNotExist, queueNoCurrentTrack } from '../../../utils/validation/queueValidator';
 import { notInSameVoiceChannel, notInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
@@ -23,7 +25,22 @@ const ffmpegFilterOptions: FFmpegFilterOptions = config.get('ffmpegFilterOptions
 
 class FiltersCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder().setName('filters').setDescription('Toggle various audio filters.');
+        const data = new SlashCommandBuilder()
+            .setName('filters')
+            .setDescription('Toggle various audio filters.')
+            .addStringOption((option) =>
+                option
+                    .setName('type')
+                    .setDescription('Audio filtering type to use.')
+                    .setRequired(false)
+                    .addChoices(
+                        { name: 'FFmpeg', value: 'ffmpeg' },
+                        { name: 'Biquad', value: 'biquad' },
+                        { name: 'Equalizer', value: 'equalizer' },
+                        { name: 'Disable', value: 'disable' }
+                    )
+            );
+
         super(data);
     }
 
@@ -46,6 +63,33 @@ class FiltersCommand extends BaseSlashCommandInteraction {
             }
         }
 
+        const filterProvider: string = interaction.options.getString('type') || 'ffmpeg';
+
+        switch (filterProvider) {
+            case 'ffmpeg':
+                logger.info('Handling ffmpeg filters.');
+                return await this.handleFfmpegFilters(queue, logger, interaction);
+            case 'biquad':
+                logger.info('Biquad filters are not yet implemented.');
+                break;
+            case 'equalizer':
+                logger.info('Equalizer filters are not yet implemented.');
+                break;
+            case 'disable':
+                logger.info('Disabling filters.');
+                if (queue.filters.ffmpeg.filters.length > 0) {
+                    queue.filters.ffmpeg.setFilters(false);
+                    logger.debug('Reset queue filters.');
+                }
+                logger.info('Response not yet implemented.');
+        }
+    }
+
+    private async handleFfmpegFilters(
+        queue: GuildQueue<unknown>,
+        logger: Logger,
+        interaction: ChatInputCommandInteraction
+    ) {
         const filterOptions: StringSelectMenuOptionBuilder[] = [];
 
         ffmpegFilterOptions.availableFilters.forEach((filter: FFmpegFilterOption) => {

--- a/src/interactions/commands/player/filters.ts
+++ b/src/interactions/commands/player/filters.ts
@@ -18,8 +18,8 @@ import { Logger } from 'pino';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { FFmpegFilterOption, FFmpegFilterOptions } from '../../../types/configTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
-import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 const ffmpegFilterOptions: FFmpegFilterOptions = config.get('ffmpegFilterOptions');
 

--- a/src/interactions/commands/player/filters.ts
+++ b/src/interactions/commands/player/filters.ts
@@ -18,8 +18,8 @@ import { Logger } from 'pino';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { FFmpegFilterOption, FFmpegFilterOptions } from '../../../types/configTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
-import { queueDoesNotExist, queueNoCurrentTrack } from '../../../utils/validation/queueValidator';
-import { notInSameVoiceChannel, notInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
+import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 const ffmpegFilterOptions: FFmpegFilterOptions = config.get('ffmpegFilterOptions');
 
@@ -34,19 +34,19 @@ class FiltersCommand extends BaseSlashCommandInteraction {
                     .setDescription('Audio filtering type to use.')
                     .setRequired(false)
                     .addChoices(
-                        { name: 'FFmpeg', value: 'ffmpeg' },
-                        { name: 'Biquad', value: 'biquad' },
-                        { name: 'Equalizer', value: 'equalizer' },
-                        { name: 'Disable', value: 'disable' }
+                        { name: 'FFmpeg', value: 'FFmpeg' },
+                        { name: 'Biquad', value: 'Biquad' },
+                        { name: 'Equalizer', value: 'Equalizer' },
+                        { name: 'Disable', value: 'Disable' }
                     )
             );
         super(data);
 
         this.validators = [
-            (args) => notInVoiceChannel(args),
-            (args) => notInSameVoiceChannel(args),
-            (args) => queueDoesNotExist(args),
-            (args) => queueNoCurrentTrack(args)
+            (args) => checkInVoiceChannel(args),
+            (args) => checkSameVoiceChannel(args),
+            (args) => checkQueueExists(args),
+            (args) => checkQueueCurrentTrack(args)
         ];
     }
 
@@ -56,11 +56,9 @@ class FiltersCommand extends BaseSlashCommandInteraction {
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
-        await this.runValidators({ interaction, queue, executionId }).catch(() => {
-            return;
-        });
+        await this.runValidators({ interaction, queue, executionId });
 
-        const filterProvider: string = interaction.options.getString('type') || 'ffmpeg';
+        const filterProvider: string = interaction.options.getString('type') || 'FFmpeg';
 
         switch (filterProvider) {
             case 'ffmpeg':

--- a/src/interactions/commands/player/leave.ts
+++ b/src/interactions/commands/player/leave.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { queueDoesNotExist } from '../../../utils/validation/queueValidator';
-import { notInSameVoiceChannel, notInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class LeaveCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -11,6 +11,12 @@ class LeaveCommand extends BaseSlashCommandInteraction {
             .setName('leave')
             .setDescription('Clear the queue and remove bot from voice channel.');
         super(data);
+
+        this.validators = [
+            (args) => checkInVoiceChannel(args),
+            (args) => checkSameVoiceChannel(args),
+            (args) => checkQueueExists(args)
+        ];
     }
 
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
@@ -19,45 +25,30 @@ class LeaveCommand extends BaseSlashCommandInteraction {
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
-        const validators = [
-            () => notInVoiceChannel({ interaction, executionId }),
-            () => notInSameVoiceChannel({ interaction, queue, executionId }),
-            () => queueDoesNotExist({ interaction, queue, executionId })
-        ];
+        await this.runValidators({ interaction, queue, executionId });
 
-        for (const validator of validators) {
-            if (await validator()) {
-                return;
-            }
-        }
+        logger.info('Validators passed, clearing queue.');
 
-        if (!queue.deleted) {
-            queue.delete();
-            logger.debug('Deleted the queue.');
-        }
-
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
+        logger.debug('Deleting queue.');
+        await this.deleteQueue(queue);
 
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.success} Leaving channel**\nCleared the track queue and left voice channel.\n\nTo play more music, use the **\`/play\`** command!`
                     )
                     .setColor(this.embedOptions.colors.success)
             ]
         });
+    }
+
+    protected async deleteQueue(queue: GuildQueue): Promise<void> {
+        if (!queue.deleted) {
+            queue.delete();
+        }
     }
 }
 

--- a/src/interactions/commands/player/leave.ts
+++ b/src/interactions/commands/player/leave.ts
@@ -3,7 +3,7 @@ import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class LeaveCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -36,7 +36,7 @@ class LeaveCommand extends BaseSlashCommandInteraction {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor(await this.getEmbedAuthor(interaction))
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.success} Leaving channel**\nCleared the track queue and left voice channel.\n\nTo play more music, use the **\`/play\`** command!`
                     )

--- a/src/interactions/commands/player/loop.ts
+++ b/src/interactions/commands/player/loop.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, QueueRepeatMode, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, SlashCommandBuilder, SlashCommandStringOption } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { EmbedBuilder, SlashCommandBuilder, SlashCommandStringOption } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class LoopCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -106,14 +106,6 @@ class LoopCommand extends BaseSlashCommandInteraction {
             });
         }
 
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
-
         if (queue.repeatMode === 0) {
             logger.debug('Disabled loop mode.');
 
@@ -122,10 +114,7 @@ class LoopCommand extends BaseSlashCommandInteraction {
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
-                        .setAuthor({
-                            name: authorName,
-                            iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                        })
+                        .setAuthor(await this.getEmbedUserAuthor(interaction))
                         .setDescription(
                             `**${this.embedOptions.icons.success} Loop mode disabled**\nChanging loop mode from **\`${currentModeUserString}\`** to **\`${modeUserString}\`**.\n\nThe ${currentModeUserString} will no longer play on repeat!`
                         )
@@ -141,10 +130,7 @@ class LoopCommand extends BaseSlashCommandInteraction {
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
-                        .setAuthor({
-                            name: authorName,
-                            iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                        })
+                        .setAuthor(await this.getEmbedUserAuthor(interaction))
                         .setDescription(
                             `**${this.embedOptions.icons.autoplaying} Loop mode changed**\nChanging loop mode from **\`${currentModeUserString}\`** to **\`${modeUserString}\`**.\n\nWhen the queue is empty, similar tracks will start playing!`
                         )
@@ -159,10 +145,7 @@ class LoopCommand extends BaseSlashCommandInteraction {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.looping} Loop mode changed**\nChanging loop mode from **\`${currentModeUserString}\`** to **\`${modeUserString}\`**.\n\nThe ${modeUserString} will now play on repeat!`
                     )

--- a/src/interactions/commands/player/lyrics.ts
+++ b/src/interactions/commands/player/lyrics.ts
@@ -1,10 +1,10 @@
 import { LyricsData, lyricsExtractor } from '@discord-player/extractor';
 import { GuildQueue, Player, QueryType, useMainPlayer, useQueue } from 'discord-player';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class LyricsCommand extends BaseSlashCommandInteraction {
     constructor() {

--- a/src/interactions/commands/player/lyrics.ts
+++ b/src/interactions/commands/player/lyrics.ts
@@ -3,8 +3,8 @@ import { GuildQueue, Player, QueryType, useMainPlayer, useQueue } from 'discord-
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { queueDoesNotExist, queueNoCurrentTrack } from '../../../utils/validation/queueValidator';
-import { notInSameVoiceChannel, notInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
+import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class LyricsCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -21,29 +21,26 @@ class LyricsCommand extends BaseSlashCommandInteraction {
                     .setAutocomplete(true)
             );
         super(data);
+
+        this.validators = [
+            (args) => checkInVoiceChannel(args),
+            (args) => checkSameVoiceChannel(args),
+            (args) => checkQueueExists(args),
+            (args) => checkQueueCurrentTrack(args)
+        ];
     }
 
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
 
-        const query: string = interaction.options.getString('query')!;
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
+
+        const query: string = interaction.options.getString('query')!;
         let geniusSearchQuery: string = '';
 
         if (!query) {
-            const validators = [
-                () => notInVoiceChannel({ interaction, executionId }),
-                () => notInSameVoiceChannel({ interaction, queue, executionId }),
-                () => queueDoesNotExist({ interaction, queue, executionId }),
-                () => queueNoCurrentTrack({ interaction, queue, executionId })
-            ];
-
-            for (const validator of validators) {
-                if (await validator()) {
-                    return;
-                }
-            }
+            await this.runValidators({ interaction, queue, executionId });
 
             geniusSearchQuery = queue.currentTrack!.title.slice(0, 50);
 

--- a/src/interactions/commands/player/nowplaying.ts
+++ b/src/interactions/commands/player/nowplaying.ts
@@ -13,8 +13,8 @@ import {
 import { PlayerOptions } from '../../../types/configTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType, TrackMetadata } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { queueDoesNotExist, queueNoCurrentTrack } from '../../../utils/validation/queueValidator';
-import { notInSameVoiceChannel, notInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
+import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 const playerOptions: PlayerOptions = config.get('playerOptions');
 
@@ -24,6 +24,13 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
             .setName('nowplaying')
             .setDescription('Show information about the current track.');
         super(data);
+
+        this.validators = [
+            (args) => checkInVoiceChannel(args),
+            (args) => checkSameVoiceChannel(args),
+            (args) => checkQueueExists(args),
+            (args) => checkQueueCurrentTrack(args)
+        ];
     }
 
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
@@ -32,19 +39,7 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
-        // TODO: define TS type for validators
-        const validators = [
-            () => notInVoiceChannel({ interaction, executionId }),
-            () => notInSameVoiceChannel({ interaction, queue, executionId }),
-            () => queueDoesNotExist({ interaction, queue, executionId }),
-            () => queueNoCurrentTrack({ interaction, queue, executionId })
-        ];
-
-        for (const validator of validators) {
-            if (await validator()) {
-                return;
-            }
-        }
+        await this.runValidators({ interaction, queue, executionId });
 
         const sourceStringsFormatted: Map<string, string> = new Map([
             ['youtube', 'YouTube'],

--- a/src/interactions/commands/player/nowplaying.ts
+++ b/src/interactions/commands/player/nowplaying.ts
@@ -10,11 +10,11 @@ import {
     EmbedBuilder,
     SlashCommandBuilder
 } from 'discord.js';
+import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { PlayerOptions } from '../../../types/configTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType, TrackMetadata } from '../../../types/interactionTypes';
-import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 const playerOptions: PlayerOptions = config.get('playerOptions');
 
@@ -132,10 +132,7 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: `Channel: ${queue.channel!.name} (${queue.channel!.bitrate / 1000}kbps)`,
-                        iconURL: interaction.guild!.iconURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedQueueAuthor(interaction, queue))
                     .setDescription(
                         (queue.node.isPaused()
                             ? '**Currently Paused**\n'

--- a/src/interactions/commands/player/pause.ts
+++ b/src/interactions/commands/player/pause.ts
@@ -1,10 +1,9 @@
 import { GuildQueue, Track, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
-
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class PauseCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -42,22 +41,11 @@ class PauseCommand extends BaseSlashCommandInteraction {
         queue.node.setPaused(!queue.node.isPaused());
         logger.debug(`Set paused state to ${queue.node.isPaused()}.`);
 
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
-
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.pauseResumed} ${
                             queue.node.isPaused() ? 'Paused Track' : 'Resumed track'

--- a/src/interactions/commands/player/play.ts
+++ b/src/interactions/commands/player/play.ts
@@ -238,22 +238,11 @@ class PlayCommand extends BaseSlashCommandInteraction {
         if (searchResult.playlist && searchResult.tracks.length > 1) {
             logger.debug(`Playlist found and added with player.play(). Query: '${query}'`);
 
-            let authorName: string;
-
-            if (interaction.member instanceof GuildMember) {
-                authorName = interaction.member.nickname || interaction.user.username;
-            } else {
-                authorName = interaction.user.username;
-            }
-
             logger.debug('Responding with success embed.');
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
-                        .setAuthor({
-                            name: authorName,
-                            iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                        })
+                        .setAuthor(await this.getEmbedUserAuthor(interaction))
                         .setDescription(
                             `**${this.embedOptions.icons.success} Added playlist to queue**\n**${durationFormat} [${
                                 track.title
@@ -270,22 +259,11 @@ class PlayCommand extends BaseSlashCommandInteraction {
         if (queue && queue.currentTrack === track && queue.tracks.data.length === 0) {
             logger.debug(`Track found and added with player.play(), started playing. Query: '${query}'.`);
 
-            let authorName: string;
-
-            if (interaction.member instanceof GuildMember) {
-                authorName = interaction.member.nickname || interaction.user.username;
-            } else {
-                authorName = interaction.user.username;
-            }
-
             logger.debug('Responding with success embed.');
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
-                        .setAuthor({
-                            name: authorName,
-                            iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                        })
+                        .setAuthor(await this.getEmbedUserAuthor(interaction))
                         .setDescription(
                             `**${this.embedOptions.icons.audioStartedPlaying} Started playing**\n**${durationFormat} [${
                                 track.title
@@ -299,22 +277,11 @@ class PlayCommand extends BaseSlashCommandInteraction {
 
         logger.debug(`Track found and added with player.play(), added to queue. Query: '${query}'.`);
 
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
-
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `${this.embedOptions.icons.success} **Added to queue**\n**${durationFormat} [${track.title}](${
                             track.raw.url ?? track.url

--- a/src/interactions/commands/player/queue.ts
+++ b/src/interactions/commands/player/queue.ts
@@ -1,11 +1,11 @@
 import config from 'config';
 import { GuildQueue, PlayerTimestamp, Track, useQueue } from 'discord-player';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { PlayerOptions } from '../../../types/configTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
-import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 const playerOptions: PlayerOptions = config.get('playerOptions');
 
@@ -103,10 +103,7 @@ class QueueCommand extends BaseSlashCommandInteraction {
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
-                        .setAuthor({
-                            name: `Channel: ${queue.channel!.name} (${queue.channel!.bitrate / 1000}kbps)`,
-                            iconURL: interaction.guild!.iconURL() || this.embedOptions.info.fallbackIconUrl
-                        })
+                        .setAuthor(await this.getEmbedQueueAuthor(interaction, queue))
                         .setDescription(
                             `${repeatModeString}` +
                                 `**${this.embedOptions.icons.queue} Tracks in queue**\n${queueString}`
@@ -141,10 +138,7 @@ class QueueCommand extends BaseSlashCommandInteraction {
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
-                        .setAuthor({
-                            name: `Channel: ${queue.channel!.name} (${queue.channel!.bitrate / 1000}kbps)`,
-                            iconURL: interaction.guild!.iconURL() || this.embedOptions.info.fallbackIconUrl
-                        })
+                        .setAuthor(await this.getEmbedQueueAuthor(interaction, queue))
                         .setDescription(
                             `**${this.embedOptions.icons.audioPlaying} Now playing**\n` +
                                 (currentTrack

--- a/src/interactions/commands/player/remove.ts
+++ b/src/interactions/commands/player/remove.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, Track, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class RemoveCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -63,22 +63,11 @@ class RemoveCommand extends BaseSlashCommandInteraction {
             durationFormat = `${this.embedOptions.icons.liveTrack} \`LIVE\``;
         }
 
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
-
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.success} Removed track**\n**${durationFormat} [${
                             removedTrack.title

--- a/src/interactions/commands/player/seek.ts
+++ b/src/interactions/commands/player/seek.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class SeekCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -141,22 +141,11 @@ class SeekCommand extends BaseSlashCommandInteraction {
         queue.node.seek(durationInMilliseconds);
         logger.debug(`Seeked to '${durationString}' in current track.`);
 
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
-
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.success} Seeking to duration**\nSeeking to **\`${durationString}\`** in current track.`
                     )

--- a/src/interactions/commands/player/shuffle.ts
+++ b/src/interactions/commands/player/shuffle.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { checkQueueExists, checkQueueEmpty } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { checkQueueEmpty, checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class ShuffleCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -31,22 +31,11 @@ class ShuffleCommand extends BaseSlashCommandInteraction {
         queue.tracks.shuffle();
         logger.debug('Shuffled queue tracks.');
 
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
-
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.shuffled} Shuffled queue tracks**\nThe **${queue.tracks.data.length}** tracks in the queue has been shuffled.\n\nView the new queue order with **\`/queue\`**.`
                     )

--- a/src/interactions/commands/player/skip.ts
+++ b/src/interactions/commands/player/skip.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, Track, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class SkipCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -63,22 +63,11 @@ class SkipCommand extends BaseSlashCommandInteraction {
                 queue.node.skipTo(skipToTrack - 1);
                 logger.debug('Skipped to specified track number.');
 
-                let authorName: string;
-
-                if (interaction.member instanceof GuildMember) {
-                    authorName = interaction.member.nickname || interaction.user.username;
-                } else {
-                    authorName = interaction.user.username;
-                }
-
                 logger.debug('Responding with success embed.');
                 return await interaction.editReply({
                     embeds: [
                         new EmbedBuilder()
-                            .setAuthor({
-                                name: authorName,
-                                iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                            })
+                            .setAuthor(await this.getEmbedUserAuthor(interaction))
                             .setDescription(
                                 `**${this.embedOptions.icons.skipped} Skipped track**\n**${durationFormat} [${
                                     skippedTrack.title
@@ -134,22 +123,11 @@ class SkipCommand extends BaseSlashCommandInteraction {
 
             const repeatModeString: string = queue.repeatMode === 0 ? '' : getRepeatModeMessage(queue.repeatMode);
 
-            let authorName: string;
-
-            if (interaction.member instanceof GuildMember) {
-                authorName = interaction.member.nickname || interaction.user.username;
-            } else {
-                authorName = interaction.user.username;
-            }
-
             logger.debug('Responding with success embed.');
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
-                        .setAuthor({
-                            name: authorName,
-                            iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                        })
+                        .setAuthor(await this.getEmbedUserAuthor(interaction))
                         .setDescription(
                             `**${this.embedOptions.icons.skipped} Skipped track**\n**${durationFormat} [${
                                 skippedTrack.title

--- a/src/interactions/commands/player/skip.ts
+++ b/src/interactions/commands/player/skip.ts
@@ -2,8 +2,8 @@ import { GuildQueue, Track, useQueue } from 'discord-player';
 import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { queueDoesNotExist, queueNoCurrentTrack } from '../../../utils/validation/queueValidator';
-import { notInSameVoiceChannel, notInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkQueueExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
+import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class SkipCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -14,6 +14,13 @@ class SkipCommand extends BaseSlashCommandInteraction {
                 option.setName('tracknumber').setDescription('The position in queue to skip to.').setMinValue(1)
             );
         super(data);
+
+        this.validators = [
+            (args) => checkInVoiceChannel(args),
+            (args) => checkSameVoiceChannel(args),
+            (args) => checkQueueExists(args),
+            (args) => checkQueueCurrentTrack(args)
+        ];
     }
 
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
@@ -22,18 +29,7 @@ class SkipCommand extends BaseSlashCommandInteraction {
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
-        const validators = [
-            () => notInVoiceChannel({ interaction, executionId }),
-            () => notInSameVoiceChannel({ interaction, queue, executionId }),
-            () => queueDoesNotExist({ interaction, queue, executionId }),
-            () => queueNoCurrentTrack({ interaction, queue, executionId })
-        ];
-
-        for (const validator of validators) {
-            if (await validator()) {
-                return;
-            }
-        }
+        await this.runValidators({ interaction, queue, executionId });
 
         const skipToTrack: number = interaction.options.getNumber('tracknumber')!;
 

--- a/src/interactions/commands/player/stop.ts
+++ b/src/interactions/commands/player/stop.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class StopCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -34,22 +34,11 @@ class StopCommand extends BaseSlashCommandInteraction {
             logger.debug('Cleared and stopped the queue.');
         }
 
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
-
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.success} Stopped playing**\nStopped playing audio and cleared the track queue.\n\nTo play more music, use the **\`/play\`** command!`
                     )

--- a/src/interactions/commands/player/volume.ts
+++ b/src/interactions/commands/player/volume.ts
@@ -2,8 +2,8 @@ import { GuildQueue, useQueue } from 'discord-player';
 import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { queueDoesNotExist } from '../../../utils/validation/queueValidator';
-import { notInSameVoiceChannel, notInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class VolumeCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -18,6 +18,12 @@ class VolumeCommand extends BaseSlashCommandInteraction {
                     .setMaxValue(100)
             );
         super(data);
+
+        this.validators = [
+            (args) => checkInVoiceChannel(args),
+            (args) => checkSameVoiceChannel(args),
+            (args) => checkQueueExists(args)
+        ];
     }
 
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
@@ -26,17 +32,7 @@ class VolumeCommand extends BaseSlashCommandInteraction {
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
-        const validators = [
-            () => notInVoiceChannel({ interaction, executionId }),
-            () => notInSameVoiceChannel({ interaction, queue, executionId }),
-            () => queueDoesNotExist({ interaction, queue, executionId })
-        ];
-
-        for (const validator of validators) {
-            if (await validator()) {
-                return;
-            }
-        }
+        await this.runValidators({ interaction, queue, executionId });
 
         const volume: number = interaction.options.getNumber('percentage')!;
 

--- a/src/interactions/commands/player/volume.ts
+++ b/src/interactions/commands/player/volume.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, SlashCommandBuilder } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 
 class VolumeCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -72,23 +72,12 @@ class VolumeCommand extends BaseSlashCommandInteraction {
             queue.node.setVolume(volume);
             logger.debug(`Set volume to ${volume}%.`);
 
-            let authorName: string;
-
-            if (interaction.member instanceof GuildMember) {
-                authorName = interaction.member.nickname || interaction.user.username;
-            } else {
-                authorName = interaction.user.username;
-            }
-
             if (volume === 0) {
                 logger.debug('Responding with success embed.');
                 return await interaction.editReply({
                     embeds: [
                         new EmbedBuilder()
-                            .setAuthor({
-                                name: authorName,
-                                iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                            })
+                            .setAuthor(await this.getEmbedUserAuthor(interaction))
                             .setDescription(
                                 `**${this.embedOptions.icons.volumeMuted} Audio muted**\nPlayback audio has been muted, because volume was set to **\`${volume}%\`**.`
                             )
@@ -101,10 +90,7 @@ class VolumeCommand extends BaseSlashCommandInteraction {
             return await interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
-                        .setAuthor({
-                            name: authorName,
-                            iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                        })
+                        .setAuthor(await this.getEmbedUserAuthor(interaction))
                         .setDescription(
                             `**${this.embedOptions.icons.volumeChanged} Volume changed**\nPlayback volume has been changed to **\`${volume}%\`**.`
                         )

--- a/src/interactions/commands/system/guilds.ts
+++ b/src/interactions/commands/system/guilds.ts
@@ -1,6 +1,6 @@
 import { EmbedBuilder, Guild, SlashCommandBuilder } from 'discord.js';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
 
 class GuildsCommand extends BaseSlashCommandInteraction {

--- a/src/interactions/commands/system/guilds.ts
+++ b/src/interactions/commands/system/guilds.ts
@@ -1,7 +1,7 @@
 import { EmbedBuilder, Guild, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { notValidGuildId } from '../../../utils/validation/systemCommandValidator';
+import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
 
 class GuildsCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -10,15 +10,15 @@ class GuildsCommand extends BaseSlashCommandInteraction {
             .setDescription('Show the top 25 guilds by member count.');
         const isSystemCommand: boolean = true;
         super(data, isSystemCommand);
+
+        this.validators = [(args) => checkValidGuildId(args)];
     }
 
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction, client } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
 
-        if (await notValidGuildId({ interaction, executionId })) {
-            return;
-        }
+        await this.runValidators({ interaction, executionId });
 
         let shardGuilds: Guild[] = [];
         let totalGuildCount: number = 0;

--- a/src/interactions/commands/system/reload.ts
+++ b/src/interactions/commands/system/reload.ts
@@ -1,7 +1,7 @@
 import { ApplicationCommandOption, ApplicationCommandOptionData, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { ExtendedClient } from '../../../types/clientTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
-import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
 
 class ReloadCommand extends BaseSlashCommandInteraction {

--- a/src/interactions/commands/system/reload.ts
+++ b/src/interactions/commands/system/reload.ts
@@ -2,7 +2,7 @@ import { ApplicationCommandOption, ApplicationCommandOptionData, EmbedBuilder, S
 import { ExtendedClient } from '../../../types/clientTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { notValidGuildId } from '../../../utils/validation/systemCommandValidator';
+import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
 
 class ReloadCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -11,15 +11,15 @@ class ReloadCommand extends BaseSlashCommandInteraction {
             .setDescription('Reload slash command, autocomplete and component interactions across shards.');
         const isSystemCommand: boolean = true;
         super(data, isSystemCommand);
+
+        this.validators = [(args) => checkValidGuildId(args)];
     }
 
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction, client } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
 
-        if (await notValidGuildId({ interaction, executionId })) {
-            return;
-        }
+        await this.runValidators({ interaction, executionId });
 
         try {
             logger.debug('Reloading interaction module across all shards.');

--- a/src/interactions/commands/system/shards.ts
+++ b/src/interactions/commands/system/shards.ts
@@ -2,7 +2,7 @@ import { EmbedBuilder, EmbedField, SlashCommandBuilder } from 'discord.js';
 import { ExtendedClient } from '../../../types/clientTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType, ShardInfo } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
-import { notValidGuildId } from '../../../utils/validation/systemCommandValidator';
+import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
 
 class ShardsCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -29,15 +29,15 @@ class ShardsCommand extends BaseSlashCommandInteraction {
             );
         const isSystemCommand: boolean = true;
         super(data, isSystemCommand);
+
+        this.validators = [(args) => checkValidGuildId(args)];
     }
 
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction, client } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
 
-        if (await notValidGuildId({ interaction, executionId })) {
-            return;
-        }
+        await this.runValidators({ interaction, executionId });
 
         let shardInfoList: ShardInfo[] = [];
 

--- a/src/interactions/commands/system/shards.ts
+++ b/src/interactions/commands/system/shards.ts
@@ -1,7 +1,7 @@
 import { EmbedBuilder, EmbedField, SlashCommandBuilder } from 'discord.js';
+import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { ExtendedClient } from '../../../types/clientTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType, ShardInfo } from '../../../types/interactionTypes';
-import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
 
 class ShardsCommand extends BaseSlashCommandInteraction {

--- a/src/interactions/commands/system/systemstatus.ts
+++ b/src/interactions/commands/system/systemstatus.ts
@@ -2,8 +2,8 @@ import { EmbedBuilder, Guild, SlashCommandBuilder } from 'discord.js';
 import osu from 'node-os-utils';
 // @ts-ignore
 import { dependencies, version } from '../../../../package.json';
-import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { getUptimeFormatted } from '../../../utils/system/getUptimeFormatted';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
 

--- a/src/interactions/commands/system/systemstatus.ts
+++ b/src/interactions/commands/system/systemstatus.ts
@@ -5,7 +5,7 @@ import { dependencies, version } from '../../../../package.json';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { getUptimeFormatted } from '../../../utils/system/getUptimeFormatted';
-import { notValidGuildId } from '../../../utils/validation/systemCommandValidator';
+import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
 
 class SystemStatusCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -14,15 +14,15 @@ class SystemStatusCommand extends BaseSlashCommandInteraction {
             .setDescription('Show operational status of the bot with additional technical information.');
         const isSystemCommand: boolean = true;
         super(data, isSystemCommand);
+
+        this.validators = [(args) => checkValidGuildId(args)];
     }
 
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction, client } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
 
-        if (await notValidGuildId({ interaction, executionId })) {
-            return;
-        }
+        await this.runValidators({ interaction, executionId });
 
         // from normal /status command
         const uptimeString: string = await getUptimeFormatted({ executionId });

--- a/src/interactions/components/filters-disable-button.ts
+++ b/src/interactions/components/filters-disable-button.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember } from 'discord.js';
-import { BaseComponentParams, BaseComponentReturnType } from '../../types/interactionTypes';
+import { EmbedBuilder } from 'discord.js';
 import { BaseComponentInteraction } from '../../classes/interactions';
+import { BaseComponentParams, BaseComponentReturnType } from '../../types/interactionTypes';
 import { checkQueueExists } from '../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../utils/validation/voiceChannelValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../utils/validation/voiceChannelValidator';
 
 class FiltersDisableButtonComponent extends BaseComponentInteraction {
     constructor() {
@@ -30,22 +30,11 @@ class FiltersDisableButtonComponent extends BaseComponentInteraction {
             logger.debug('Reset queue filters.');
         }
 
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
-
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.success} Disabled filters**\nAll audio filters have been disabled.`
                     )

--- a/src/interactions/components/filters-select-menu.ts
+++ b/src/interactions/components/filters-select-menu.ts
@@ -1,11 +1,12 @@
 import config from 'config';
 import { GuildQueue, QueueFilters, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember, StringSelectMenuInteraction } from 'discord.js';
+import { EmbedBuilder, StringSelectMenuInteraction } from 'discord.js';
+import { BaseComponentInteraction } from '../../classes/interactions';
 import { FFmpegFilterOption, FFmpegFilterOptions } from '../../types/configTypes';
 import { BaseComponentParams, BaseComponentReturnType } from '../../types/interactionTypes';
-import { BaseComponentInteraction } from '../../classes/interactions';
 import { checkQueueExists } from '../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../utils/validation/voiceChannelValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../utils/validation/voiceChannelValidator';
+
 const ffmpegFilterOptions: FFmpegFilterOptions = config.get('ffmpegFilterOptions');
 
 class FiltersSelectMenuComponent extends BaseComponentInteraction {
@@ -61,22 +62,11 @@ class FiltersSelectMenuComponent extends BaseComponentInteraction {
         queue.filters.ffmpeg.toggle(selectMenuInteraction.values as (keyof QueueFilters)[]);
         logger.debug(`Enabled filters ${selectMenuInteraction.values.join(', ')}.`);
 
-        let authorName: string;
-
-        if (selectMenuInteraction.member instanceof GuildMember) {
-            authorName = selectMenuInteraction.member.nickname || selectMenuInteraction.user.username;
-        } else {
-            authorName = selectMenuInteraction.user.username;
-        }
-
         logger.debug('Responding with success embed.');
         return await selectMenuInteraction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: selectMenuInteraction.user.avatarURL() || ''
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${
                             this.embedOptions.icons.success

--- a/src/interactions/components/nowplaying-skip-button.ts
+++ b/src/interactions/components/nowplaying-skip-button.ts
@@ -1,9 +1,9 @@
 import { GuildQueue, Track, useQueue } from 'discord-player';
-import { EmbedBuilder, GuildMember } from 'discord.js';
-import { BaseComponentParams, BaseComponentReturnType } from '../../types/interactionTypes';
+import { EmbedBuilder } from 'discord.js';
 import { BaseComponentInteraction } from '../../classes/interactions';
-import { checkQueueExists, checkQueueCurrentTrack } from '../../utils/validation/queueValidator';
-import { checkSameVoiceChannel, checkInVoiceChannel } from '../../utils/validation/voiceChannelValidator';
+import { BaseComponentParams, BaseComponentReturnType } from '../../types/interactionTypes';
+import { checkQueueCurrentTrack, checkQueueExists } from '../../utils/validation/queueValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../utils/validation/voiceChannelValidator';
 
 class NowplayingSkipButton extends BaseComponentInteraction {
     constructor() {
@@ -85,22 +85,11 @@ class NowplayingSkipButton extends BaseComponentInteraction {
 
         const repeatModeString: string = queue.repeatMode === 0 ? '' : getRepeatModeMessage(queue.repeatMode);
 
-        let authorName: string;
-
-        if (interaction.member instanceof GuildMember) {
-            authorName = interaction.member.nickname || interaction.user.username;
-        } else {
-            authorName = interaction.user.username;
-        }
-
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor({
-                        name: authorName,
-                        iconURL: interaction.user.avatarURL() || this.embedOptions.info.fallbackIconUrl
-                    })
+                    .setAuthor(await this.getEmbedUserAuthor(interaction))
                     .setDescription(
                         `**${this.embedOptions.icons.skipped} Skipped track**\n**${durationFormat} [${
                             skippedTrack.title

--- a/src/interactions/components/nowplaying-skip-button.ts
+++ b/src/interactions/components/nowplaying-skip-button.ts
@@ -2,12 +2,19 @@ import { GuildQueue, Track, useQueue } from 'discord-player';
 import { EmbedBuilder, GuildMember } from 'discord.js';
 import { BaseComponentParams, BaseComponentReturnType } from '../../types/interactionTypes';
 import { BaseComponentInteraction } from '../../classes/interactions';
-import { queueDoesNotExist, queueNoCurrentTrack } from '../../utils/validation/queueValidator';
-import { notInSameVoiceChannel, notInVoiceChannel } from '../../utils/validation/voiceChannelValidator';
+import { checkQueueExists, checkQueueCurrentTrack } from '../../utils/validation/queueValidator';
+import { checkSameVoiceChannel, checkInVoiceChannel } from '../../utils/validation/voiceChannelValidator';
 
 class NowplayingSkipButton extends BaseComponentInteraction {
     constructor() {
         super('nowplaying-skip-button');
+
+        this.validators = [
+            (args) => checkInVoiceChannel(args),
+            (args) => checkSameVoiceChannel(args),
+            (args) => checkQueueExists(args),
+            (args) => checkQueueCurrentTrack(args)
+        ];
     }
 
     async execute(params: BaseComponentParams): BaseComponentReturnType {
@@ -16,18 +23,7 @@ class NowplayingSkipButton extends BaseComponentInteraction {
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
-        const validators = [
-            () => notInVoiceChannel({ interaction, executionId }),
-            () => notInSameVoiceChannel({ interaction, queue, executionId }),
-            () => queueDoesNotExist({ interaction, queue, executionId }),
-            () => queueNoCurrentTrack({ interaction, queue, executionId })
-        ];
-
-        for (const validator of validators) {
-            if (await validator()) {
-                return;
-            }
-        }
+        await this.runValidators({ interaction, queue, executionId });
 
         if (!queue || (queue.tracks.data.length === 0 && !queue.currentTrack)) {
             logger.debug('Tried skipping track but there was no queue.');

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,6 +1,5 @@
 import config from 'config';
 import pino, { DestinationStream, Logger, LoggerOptions } from 'pino';
-
 import { CustomLoggerOptions } from '../types/configTypes';
 import { TargetOptions } from '../types/serviceTypes';
 

--- a/src/types/eventTypes.d.ts
+++ b/src/types/eventTypes.d.ts
@@ -1,6 +1,5 @@
 import { GuildQueuePlayerNode } from 'discord-player';
 import { BaseGuildTextChannel } from 'discord.js';
-
 import { ExtendedClient } from './clientTypes';
 
 export type ClientEventArguments = unknown[];

--- a/src/types/interactionTypes.d.ts
+++ b/src/types/interactionTypes.d.ts
@@ -7,22 +7,26 @@ import {
 } from 'discord.js';
 import { ExtendedClient } from './clientTypes';
 
+export type PlayerStatistics = {
+    activeVoiceConnections: number;
+    totalTracks: number;
+    totalListeners: number;
+};
+
 export type ShardInfo = {
     shardId: number;
     memUsage: number;
     guildCount: number;
     guildMemberCount: number;
-    playerStatistics: {
-        activeVoiceConnections: number;
-        totalTracks: number;
-        totalListeners: number;
-    };
+    playerStatistics: PlayerStatistics;
+};
+
+export type Bridge = {
+    views: number;
 };
 
 export type TrackMetadata = {
-    bridge: {
-        views: number;
-    };
+    bridge: Bridge;
 };
 
 type BaseInteractionParams = {
@@ -48,3 +52,10 @@ export type BaseSlashCommandReturnType = Promise<Message<boolean> | void>;
 export type BaseAutocompleteReturnType = Promise<ApplicationCommandOptionChoiceData | void>;
 
 export type BaseComponentReturnType = Promise<Message<boolean> | void>;
+
+export enum FilterType {
+    FFmpeg = 'ffmpeg',
+    Biquad = 'biquad',
+    Equalizer = 'equalizer',
+    Disable = 'disable'
+}

--- a/src/types/utilTypes.d.ts
+++ b/src/types/utilTypes.d.ts
@@ -23,6 +23,8 @@ export type CustomEvent = {
     isPlayerEvent?: boolean;
 };
 
+export type Validator = (args: ValidatorParams) => Promise<void>;
+
 export type ValidatorParams = {
     interaction: ChatInputCommandInteraction | MessageComponentInteraction;
     queue?: GuildQueue;

--- a/src/types/utilTypes.d.ts
+++ b/src/types/utilTypes.d.ts
@@ -1,6 +1,5 @@
 import { GuildQueue, Player } from 'discord-player';
 import { ChatInputCommandInteraction, MessageComponentInteraction } from 'discord.js';
-
 import { ExtendedClient } from './clientTypes';
 
 export type RegisterEventListenersParams = {

--- a/src/types/utilTypes.d.ts
+++ b/src/types/utilTypes.d.ts
@@ -23,52 +23,14 @@ export type CustomEvent = {
     isPlayerEvent?: boolean;
 };
 
-export type NotInVoiceChannelParams = {
+export type ValidatorParams = {
     interaction: ChatInputCommandInteraction | MessageComponentInteraction;
-    executionId: string;
-};
-
-export type NotInSameVoiceChannelParams = {
-    interaction: ChatInputCommandInteraction | MessageComponentInteraction;
-    queue: GuildQueue;
-    executionId: string;
-};
-
-export type NotValidGuildIdParams = {
-    interaction: ChatInputCommandInteraction | MessageComponentInteraction;
+    queue?: GuildQueue;
     executionId: string;
 };
 
 export type TransformQueryParams = {
     query: string;
-    executionId: string;
-};
-
-export type QueueDoesNotExistParams = {
-    interaction: ChatInputCommandInteraction | MessageComponentInteraction;
-    queue: GuildQueue;
-    executionId: string;
-};
-
-export type QueueNoCurrentTrackParams = {
-    interaction: ChatInputCommandInteraction | MessageComponentInteraction;
-    queue: GuildQueue;
-    executionId: string;
-};
-
-export type QueueIsEmptyParams = {
-    interaction: ChatInputCommandInteraction | MessageComponentInteraction;
-    queue: GuildQueue;
-    executionId: string;
-};
-
-export type CannotJoinVoiceOrTalkParams = {
-    interaction: ChatInputCommandInteraction | MessageComponentInteraction;
-    executionId: string;
-};
-
-export type CannotSendMessageInChannelParams = {
-    interaction: ChatInputCommandInteraction | MessageComponentInteraction;
     executionId: string;
 };
 

--- a/src/utils/deploySlashCommands.ts
+++ b/src/utils/deploySlashCommands.ts
@@ -1,19 +1,16 @@
-import 'dotenv/config';
-
 import config from 'config';
 import { REST, RESTPostAPIChatInputApplicationCommandsJSONBody, RouteLike, Routes } from 'discord.js';
+import 'dotenv/config';
+import { randomUUID as uuidv4 } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { randomUUID as uuidv4 } from 'node:crypto';
-
+import { Logger } from 'pino';
 import loggerModule from '../services/logger';
 import { SystemOptions } from '../types/configTypes';
-import { Logger } from 'pino';
 
 const systemOptions: SystemOptions = config.get('systemOptions');
 
 const executionId: string = uuidv4();
-
 const logger: Logger = loggerModule.child({
     module: 'deploy',
     name: 'deploySlashCommands',

--- a/src/utils/factory/createClient.ts
+++ b/src/utils/factory/createClient.ts
@@ -1,7 +1,6 @@
 import Discord, { Client } from 'discord.js';
-
-import loggerModule from '../../services/logger';
 import { Logger } from 'pino';
+import loggerModule from '../../services/logger';
 
 export const createClient = async ({ executionId }: { executionId: string }) => {
     const logger: Logger = loggerModule.child({

--- a/src/utils/other/startLoadTest.ts
+++ b/src/utils/other/startLoadTest.ts
@@ -1,6 +1,5 @@
 import config from 'config';
 import { Channel, Client } from 'discord.js';
-
 import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { LoadTestOptions } from '../../types/configTypes';

--- a/src/utils/registerClientInteractions.ts
+++ b/src/utils/registerClientInteractions.ts
@@ -1,11 +1,10 @@
 import { Collection } from 'discord.js';
 import fs from 'node:fs';
 import path from 'node:path';
-
-import loggerModule from '../services/logger';
-import { RegisterClientInteractionsParams } from '../types/utilTypes';
 import { Logger } from 'pino';
+import loggerModule from '../services/logger';
 import { ExtendedClient } from '../types/clientTypes';
+import { RegisterClientInteractionsParams } from '../types/utilTypes';
 
 export const registerClientInteractions = async ({ client, executionId }: RegisterClientInteractionsParams) => {
     const logger: Logger = loggerModule.child({

--- a/src/utils/registerEventListeners.ts
+++ b/src/utils/registerEventListeners.ts
@@ -1,14 +1,13 @@
 import config from 'config';
-import fs from 'node:fs';
-import path from 'node:path';
-
 import { GuildQueueEvents, Player, PlayerEvents } from 'discord-player';
 import { Client } from 'discord.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Logger } from 'pino';
 import loggerModule from '../services/logger';
 import { CustomLoggerOptions } from '../types/configTypes';
 import { ClientEventArguments, PlayerEventArguments, ProcessEventArguments } from '../types/eventTypes';
 import { CustomEvent, RegisterEventListenersParams } from '../types/utilTypes';
-import { Logger } from 'pino';
 
 const loggerOptions: CustomLoggerOptions = config.get('loggerOptions');
 

--- a/src/utils/validation/permissionValidator.ts
+++ b/src/utils/validation/permissionValidator.ts
@@ -8,14 +8,13 @@ import {
     VoiceBasedChannel,
     VoiceChannel
 } from 'discord.js';
-
 import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
-import { CannotJoinVoiceOrTalkParams, CannotSendMessageInChannelParams } from '../../types/utilTypes';
+import { ValidatorParams } from '../../types/utilTypes';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
-export const cannotJoinVoiceOrTalk = async ({ interaction, executionId }: CannotJoinVoiceOrTalkParams) => {
+export const cannotJoinVoiceOrTalk = async ({ interaction, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'cannotJoinVoiceOrTalk',
@@ -49,7 +48,7 @@ export const cannotJoinVoiceOrTalk = async ({ interaction, executionId }: Cannot
     return false;
 };
 
-export const cannotSendMessageInChannel = async ({ interaction, executionId }: CannotSendMessageInChannelParams) => {
+export const cannotSendMessageInChannel = async ({ interaction, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'cannotSendMessageInChannel',

--- a/src/utils/validation/permissionValidator.ts
+++ b/src/utils/validation/permissionValidator.ts
@@ -9,10 +9,10 @@ import {
     VoiceChannel
 } from 'discord.js';
 import { Logger } from 'pino';
+import { InteractionValidationError } from '../../classes/interactions';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
-import { InteractionValidationError } from '../../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 export const checkVoicePermissionJoinAndTalk = async ({ interaction, executionId }: ValidatorParams) => {

--- a/src/utils/validation/permissionValidator.ts
+++ b/src/utils/validation/permissionValidator.ts
@@ -12,9 +12,10 @@ import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
+import { InteractionValidationError } from '../../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
-export const cannotJoinVoiceOrTalk = async ({ interaction, executionId }: ValidatorParams) => {
+export const checkVoicePermissionJoinAndTalk = async ({ interaction, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'cannotJoinVoiceOrTalk',
@@ -33,7 +34,7 @@ export const cannotJoinVoiceOrTalk = async ({ interaction, executionId }: Valida
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Oops!**\nI do not have permission to play audio in the voice channel you are in.\n\nPlease make sure I have the **\`Connect\`** and **\`Speak\`** permissions in this voice channel.`
+                        `**${embedOptions.icons.warning} Oops!**\nI do not have permission to play audio in the voice channel <#${channel.id}>.\n\nPlease make sure I have the **\`Connect\`** and **\`Speak\`** permissions in this voice channel.`
                     )
                     .setColor(embedOptions.colors.warning)
             ]
@@ -42,13 +43,13 @@ export const cannotJoinVoiceOrTalk = async ({ interaction, executionId }: Valida
         logger.debug(
             `User tried to use command '${interactionIdentifier}' but the bot had no permission to join/speak in the voice channel.`
         );
-        return true;
+        throw new InteractionValidationError('Bot cannot join or speak in voice channel.');
     }
 
-    return false;
+    return;
 };
 
-export const cannotSendMessageInChannel = async ({ interaction, executionId }: ValidatorParams) => {
+export const checkChannelPermissionViewable = async ({ interaction, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'cannotSendMessageInChannel',
@@ -81,7 +82,7 @@ export const cannotSendMessageInChannel = async ({ interaction, executionId }: V
                     embeds: [
                         new EmbedBuilder()
                             .setDescription(
-                                `**${embedOptions.icons.warning} Oops!**\nI do not have permission to send message replies in the channel you are in.\n\nPlease make sure I have the **\`View Channel\`** permission in this text channel.`
+                                `**${embedOptions.icons.warning} Oops!**\nI do not have permission to send message replies in the channel <#${channel.id}>.\n\nPlease make sure I have the **\`View Channel\`** permission in this text channel.`
                             )
                             .setColor(embedOptions.colors.warning)
                     ]
@@ -106,8 +107,8 @@ export const cannotSendMessageInChannel = async ({ interaction, executionId }: V
             }
         }
 
-        return true;
+        throw new InteractionValidationError('Bot cannot send message in channel.');
     }
 
-    return false;
+    return;
 };

--- a/src/utils/validation/queueValidator.ts
+++ b/src/utils/validation/queueValidator.ts
@@ -4,9 +4,10 @@ import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
+import { InteractionValidationError } from '../../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
-export const queueDoesNotExist = async ({ interaction, queue, executionId }: ValidatorParams) => {
+export const checkQueueExists = async ({ interaction, queue, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'queueDoesNotExist',
@@ -30,13 +31,13 @@ export const queueDoesNotExist = async ({ interaction, queue, executionId }: Val
         });
 
         logger.debug(`User tried to use command '${interactionIdentifier}' but there was no queue.`);
-        return true;
+        throw new InteractionValidationError('Queue does not exist.');
     }
 
-    return false;
+    return;
 };
 
-export const queueNoCurrentTrack = async ({ interaction, queue, executionId }: ValidatorParams) => {
+export const checkQueueCurrentTrack = async ({ interaction, queue, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'queueNoCurrentTrack',
@@ -60,13 +61,13 @@ export const queueNoCurrentTrack = async ({ interaction, queue, executionId }: V
         });
 
         logger.debug(`User tried to use command '${interactionIdentifier}' but there was no current track.`);
-        return true;
+        throw new InteractionValidationError('Queue has no current track.');
     }
 
-    return false;
+    return;
 };
 
-export const queueIsEmpty = async ({ interaction, queue, executionId }: ValidatorParams) => {
+export const checkQueueEmpty = async ({ interaction, queue, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'queueIsEmpty',
@@ -90,8 +91,8 @@ export const queueIsEmpty = async ({ interaction, queue, executionId }: Validato
         });
 
         logger.debug(`User tried to use command '${interactionIdentifier}' but there was no tracks in the queue.`);
-        return true;
+        throw new InteractionValidationError('Queue is empty.');
     }
 
-    return false;
+    return;
 };

--- a/src/utils/validation/queueValidator.ts
+++ b/src/utils/validation/queueValidator.ts
@@ -1,10 +1,10 @@
 import config from 'config';
 import { EmbedBuilder, InteractionType } from 'discord.js';
 import { Logger } from 'pino';
+import { InteractionValidationError } from '../../classes/interactions';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
-import { InteractionValidationError } from '../../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 export const checkQueueExists = async ({ interaction, queue, executionId }: ValidatorParams) => {

--- a/src/utils/validation/queueValidator.ts
+++ b/src/utils/validation/queueValidator.ts
@@ -1,13 +1,12 @@
 import config from 'config';
 import { EmbedBuilder, InteractionType } from 'discord.js';
-
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
-import { QueueDoesNotExistParams, QueueIsEmptyParams, QueueNoCurrentTrackParams } from '../../types/utilTypes';
-import { Logger } from 'pino';
+import { ValidatorParams } from '../../types/utilTypes';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
-export const queueDoesNotExist = async ({ interaction, queue, executionId }: QueueDoesNotExistParams) => {
+export const queueDoesNotExist = async ({ interaction, queue, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'queueDoesNotExist',
@@ -37,7 +36,7 @@ export const queueDoesNotExist = async ({ interaction, queue, executionId }: Que
     return false;
 };
 
-export const queueNoCurrentTrack = async ({ interaction, queue, executionId }: QueueNoCurrentTrackParams) => {
+export const queueNoCurrentTrack = async ({ interaction, queue, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'queueNoCurrentTrack',
@@ -49,7 +48,7 @@ export const queueNoCurrentTrack = async ({ interaction, queue, executionId }: Q
     const interactionIdentifier =
         interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId;
 
-    if (!queue.currentTrack) {
+    if (queue && !queue.currentTrack) {
         await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
@@ -67,7 +66,7 @@ export const queueNoCurrentTrack = async ({ interaction, queue, executionId }: Q
     return false;
 };
 
-export const queueIsEmpty = async ({ interaction, queue, executionId }: QueueIsEmptyParams) => {
+export const queueIsEmpty = async ({ interaction, queue, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'queueIsEmpty',
@@ -79,7 +78,7 @@ export const queueIsEmpty = async ({ interaction, queue, executionId }: QueueIsE
     const interactionIdentifier =
         interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId;
 
-    if (queue.tracks.data.length === 0) {
+    if (queue && queue.tracks.data.length === 0) {
         await interaction.editReply({
             embeds: [
                 new EmbedBuilder()

--- a/src/utils/validation/systemCommandValidator.ts
+++ b/src/utils/validation/systemCommandValidator.ts
@@ -1,10 +1,10 @@
 import config from 'config';
 import { EmbedBuilder, InteractionType } from 'discord.js';
 import { Logger } from 'pino';
+import { InteractionValidationError } from '../../classes/interactions';
 import loggerModule from '../../services/logger';
 import { EmbedOptions, SystemOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
-import { InteractionValidationError } from '../../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const systemOptions: SystemOptions = config.get('systemOptions');

--- a/src/utils/validation/systemCommandValidator.ts
+++ b/src/utils/validation/systemCommandValidator.ts
@@ -4,10 +4,11 @@ import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { EmbedOptions, SystemOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
+import { InteractionValidationError } from '../../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const systemOptions: SystemOptions = config.get('systemOptions');
-export const notValidGuildId = async ({ interaction, executionId }: ValidatorParams) => {
+export const checkValidGuildId = async ({ interaction, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'notValidGuildId',
@@ -33,8 +34,8 @@ export const notValidGuildId = async ({ interaction, executionId }: ValidatorPar
         logger.debug(
             `User tried to use command '${interactionIdentifier}' but system command cannot be executed in the specified guild.`
         );
-        return true;
+        throw new InteractionValidationError('System command cannot be executed in the specified guild.');
     }
 
-    return false;
+    return;
 };

--- a/src/utils/validation/systemCommandValidator.ts
+++ b/src/utils/validation/systemCommandValidator.ts
@@ -1,14 +1,13 @@
 import config from 'config';
 import { EmbedBuilder, InteractionType } from 'discord.js';
-
+import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { EmbedOptions, SystemOptions } from '../../types/configTypes';
-import { NotValidGuildIdParams } from '../../types/utilTypes';
-import { Logger } from 'pino';
+import { ValidatorParams } from '../../types/utilTypes';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const systemOptions: SystemOptions = config.get('systemOptions');
-export const notValidGuildId = async ({ interaction, executionId }: NotValidGuildIdParams) => {
+export const notValidGuildId = async ({ interaction, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'notValidGuildId',

--- a/src/utils/validation/systemCommandValidator.ts
+++ b/src/utils/validation/systemCommandValidator.ts
@@ -25,7 +25,7 @@ export const notValidGuildId = async ({ interaction, executionId }: NotValidGuil
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Oops!**\nNo permission to execute this command.\n\nThe command **\`/${interactionIdentifier}\`** cannot be executed in this server.`
+                        `**${embedOptions.icons.warning} Oops!**\nNo permission to perform this action.\n\nThe command **\`/${interactionIdentifier}\`** cannot be executed in this server.`
                     )
                     .setColor(embedOptions.colors.warning)
             ]

--- a/src/utils/validation/voiceChannelValidator.ts
+++ b/src/utils/validation/voiceChannelValidator.ts
@@ -4,9 +4,10 @@ import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
+import { InteractionValidationError } from '../../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
-export const notInVoiceChannel = async ({ interaction, executionId }: ValidatorParams) => {
+export const checkInVoiceChannel = async ({ interaction, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'validator',
         name: 'notInVoiceChannel',
@@ -30,13 +31,13 @@ export const notInVoiceChannel = async ({ interaction, executionId }: ValidatorP
         });
 
         logger.debug(`User tried to use command '${interactionIdentifier}' but was not in a voice channel.`);
-        return true;
+        throw new InteractionValidationError('User not in voice channel.');
     }
 
-    return false;
+    return;
 };
 
-export const notInSameVoiceChannel = async ({ interaction, queue, executionId }: ValidatorParams) => {
+export const checkSameVoiceChannel = async ({ interaction, queue, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'notInSameVoiceChannel',
@@ -50,7 +51,7 @@ export const notInSameVoiceChannel = async ({ interaction, queue, executionId }:
 
     if (!queue || !queue.dispatcher) {
         // If there is no queue or bot is not in voice channel, then there is no need to check if user is in same voice channel.
-        return false;
+        return;
     }
 
     if (
@@ -68,8 +69,8 @@ export const notInSameVoiceChannel = async ({ interaction, queue, executionId }:
         });
 
         logger.debug(`User tried to use command '${interactionIdentifier}' but was not in the same voice channel.`);
-        return true;
+        throw new InteractionValidationError('User not in same voice channel.');
     }
 
-    return false;
+    return;
 };

--- a/src/utils/validation/voiceChannelValidator.ts
+++ b/src/utils/validation/voiceChannelValidator.ts
@@ -1,10 +1,10 @@
 import config from 'config';
 import { EmbedBuilder, GuildMember, InteractionType } from 'discord.js';
 import { Logger } from 'pino';
+import { InteractionValidationError } from '../../classes/interactions';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
-import { InteractionValidationError } from '../../classes/interactions';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 export const checkInVoiceChannel = async ({ interaction, executionId }: ValidatorParams) => {

--- a/src/utils/validation/voiceChannelValidator.ts
+++ b/src/utils/validation/voiceChannelValidator.ts
@@ -1,13 +1,12 @@
 import config from 'config';
 import { EmbedBuilder, GuildMember, InteractionType } from 'discord.js';
-
 import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
-import { NotInSameVoiceChannelParams, NotInVoiceChannelParams } from '../../types/utilTypes';
+import { ValidatorParams } from '../../types/utilTypes';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
-export const notInVoiceChannel = async ({ interaction, executionId }: NotInVoiceChannelParams) => {
+export const notInVoiceChannel = async ({ interaction, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'validator',
         name: 'notInVoiceChannel',
@@ -37,7 +36,7 @@ export const notInVoiceChannel = async ({ interaction, executionId }: NotInVoice
     return false;
 };
 
-export const notInSameVoiceChannel = async ({ interaction, queue, executionId }: NotInSameVoiceChannelParams) => {
+export const notInSameVoiceChannel = async ({ interaction, queue, executionId }: ValidatorParams) => {
     const logger: Logger = loggerModule.child({
         module: 'utilValidation',
         name: 'notInSameVoiceChannel',

--- a/src/utils/validation/voiceChannelValidator.ts
+++ b/src/utils/validation/voiceChannelValidator.ts
@@ -24,7 +24,7 @@ export const notInVoiceChannel = async ({ interaction, executionId }: NotInVoice
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Not in a voice channel**\nYou need to be in a voice channel to use this command.`
+                        `**${embedOptions.icons.warning} Not in a voice channel**\nYou need to be in a voice channel to perform this action.`
                     )
                     .setColor(embedOptions.colors.warning)
             ]
@@ -62,7 +62,7 @@ export const notInSameVoiceChannel = async ({ interaction, queue, executionId }:
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Not in same voice channel**\nYou need to be in the same voice channel as me to use this command.\n\n**Voice channel:** ${queue.dispatcher.channel.name}`
+                        `**${embedOptions.icons.warning} Not in same voice channel**\nYou need to be in the same voice channel as me to perform this action.\n\n**Voice channel:** <#${queue.dispatcher.channel.id}>`
                     )
                     .setColor(embedOptions.colors.warning)
             ]


### PR DESCRIPTION
## Changes
- Refactored handling of validators. Interactions now have a this.runValidators() method. This will run the validators specified in the constructor for the interaction, or the provided list of validators.
- Validators no longer return true/false, but return Promise<void> (nothing) or throw error if checks fail. The validation errors are moved up the chain and handled in interaction error handler.
- Refactored getting the author value to be used in embeds. This logic is now extracted out of the command logic and called with this.getEmbedUserAuthor().
- More formatting and smaller adjustments, type annotations etc.

### Dependencies
No changes.