### PR TITLE
Added `forceNormalizerByBassBoost` option to ffmpeg filter options

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -144,6 +144,7 @@ module.exports.ipRotationConfig = {
 // Configuration for ffmpeg filters for audio processing.
 module.exports.ffmpegFilterOptions = {
     threadAmount: '2',
+    forceNormalizerByBassBoost: true,
     availableFilters: [
         {
             label: 'Bass boost',

--- a/src/interactions/components/filters-select-menu.ts
+++ b/src/interactions/components/filters-select-menu.ts
@@ -49,6 +49,7 @@ class FiltersSelectMenuComponent extends BaseComponentInteraction {
 
         // if bassboost is enabled and not normalizer, also enable normalizer to avoid distrorion
         if (
+            ffmpegFilterOptions.forceNormalizerByBassBoost &&
             (selectMenuInteraction.values.includes('bassboost_low') ||
                 selectMenuInteraction.values.includes('bassboost')) &&
             !selectMenuInteraction.values.includes('normalizer')

--- a/src/types/configTypes.d.ts
+++ b/src/types/configTypes.d.ts
@@ -116,6 +116,7 @@ export type FFmpegFilterOption = {
 
 export type FFmpegFilterOptions = {
     threadAmount: string;
+    forceNormalizerByBassBoost: boolean;
     availableFilters: FFmpegFilterOption[];
 };
 


### PR DESCRIPTION

## Changes
- Introduced the `forceNormalizerByBassBoost` option to control the enforcement of normalization when bass boost is applied.
- By default this is set to `true` to keep current behavior.

### Dependencies
- No changes
