### PR TITLE
fix(playerSkip): only log on error

### DIFF
--- a/src/events/player/playerSkip.ts
+++ b/src/events/player/playerSkip.ts
@@ -1,5 +1,5 @@
 import config from 'config';
-import { Track } from 'discord-player';
+import { Track, TrackSkipReason } from 'discord-player';
 import { BaseGuildTextChannel, EmbedBuilder } from 'discord.js';
 import { randomUUID as uuidv4 } from 'node:crypto';
 import { Logger } from 'pino';
@@ -10,12 +10,18 @@ import { ExtendedGuildQueuePlayerNode } from '../../types/eventTypes';
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const botOptions: BotOptions = config.get('botOptions');
 const systemOptions: SystemOptions = config.get('systemOptions');
-// Emitted when the audio player fails to load the stream for a track
+
+// Emitted when the audio player skips a track.
 module.exports = {
     name: 'playerSkip',
     isDebug: false,
     isPlayerEvent: true,
-    execute: async (queue: ExtendedGuildQueuePlayerNode, track: Track) => {
+    execute: async (
+        queue: ExtendedGuildQueuePlayerNode,
+        track: Track,
+        reason: TrackSkipReason,
+        description: string
+    ) => {
         const executionId: string = uuidv4();
         const logger: Logger = loggerModule.child({
             module: 'event',
@@ -25,35 +31,37 @@ module.exports = {
             guildId: queue.metadata?.channel.guild.id
         });
 
-        logger.error(`player.events.on('playerSkip'): Failed to play '${track.url}'.`);
+        logger.debug(`Track [${track.url}] skipped with reason: ${reason}\n${description}`);
 
-        await queue.metadata?.channel.send({
-            embeds: [
-                new EmbedBuilder()
-                    .setDescription(
-                        `**${embedOptions.icons.error} Uh-oh... _Something_ went wrong!**\nIt seems there was an issue while loading stream for the track.\n\nIf you performed a command, you can try again.\n\n_If this problem persists, please submit a bug report in the **[support server](${botOptions.serverInviteUrl})**._`
-                    )
-                    .setColor(embedOptions.colors.error)
-                    .setFooter({ text: `Execution ID: ${executionId}` })
-            ]
-        });
-
-        if (systemOptions.systemMessageChannelId && systemOptions.systemUserId) {
-            const channel: BaseGuildTextChannel = (await queue.metadata?.client.channels.cache.get(
-                systemOptions.systemMessageChannelId
-            )) as BaseGuildTextChannel;
-            if (channel) {
-                await channel.send({
-                    embeds: [
-                        new EmbedBuilder()
-                            .setDescription(
-                                `${embedOptions.icons.error} **player.events.on('playerSkip')**\nExecution id: ${executionId}\n${track.url}` +
-                                    `\n\n<@${systemOptions.systemUserId}>`
-                            )
-                            .setColor(embedOptions.colors.error)
-                            .setFooter({ text: `Execution ID: ${executionId}` })
-                    ]
-                });
+        if (reason === TrackSkipReason.NoStream) {
+            logger.error(`player.events.on('playerSkip'): Failed to play '${track.url}'.\n${description}`);
+            await queue.metadata?.channel.send({
+                embeds: [
+                    new EmbedBuilder()
+                        .setDescription(
+                            `**${embedOptions.icons.error} Uh-oh... _Something_ went wrong!**\nIt seems there was an issue while loading stream for the track.\n\nIf you performed a command, you can try again.\n\n_If this problem persists, please submit a bug report in the **[support server](${botOptions.serverInviteUrl})**._`
+                        )
+                        .setColor(embedOptions.colors.error)
+                        .setFooter({ text: `Execution ID: ${executionId}` })
+                ]
+            });
+            if (systemOptions.systemMessageChannelId && systemOptions.systemUserId) {
+                const channel: BaseGuildTextChannel = (await queue.metadata?.client.channels.cache.get(
+                    systemOptions.systemMessageChannelId
+                )) as BaseGuildTextChannel;
+                if (channel) {
+                    await channel.send({
+                        embeds: [
+                            new EmbedBuilder()
+                                .setDescription(
+                                    `${embedOptions.icons.error} **player.events.on('playerSkip')**\nExecution id: ${executionId}\n${track.url}` +
+                                        `\n\n<@${systemOptions.systemUserId}>`
+                                )
+                                .setColor(embedOptions.colors.error)
+                                .setFooter({ text: `Execution ID: ${executionId}` })
+                        ]
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes

This PR fixes `playerSkip` event and only logs the error message if skip occurred due to an error.

### Dependencies
<!-- Added/removed any dependencies? Explain what and why here. -->
N/A
