### PR TITLE
Fix `main` package property

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "publisher": "mariusbegby",
     "license": "MIT",
-    "main": "index.js",
+    "main": "dist/index.js",
     "jest": {
         "preset": "ts-jest",
         "testEnvironment": "node",


### PR DESCRIPTION
## Changes
Now you can do `node .`. The `start-pretty*` scripts could also be updated to use `node .` instead of `./dist/index.js`.