### PR TITLE
update discord.js, undici fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
             "dependencies": {
                 "@discord-player/extractor": "^4.4.5",
                 "@discord-player/opus": "^0.1.2",
-                "@discordjs/rest": "^2.0.0",
+                "@discordjs/rest": "^2.2.0",
                 "config": "^3.3.9",
                 "discord-player": "^6.6.6",
                 "discord-voip": "^0.1.3",
-                "discord.js": "^14.12.1",
+                "discord.js": "^14.14.1",
                 "dotenv": "^16.3.1",
                 "mediaplex": "^0.0.9",
                 "node-os-utils": "^1.3.7",
@@ -750,17 +750,17 @@
             }
         },
         "node_modules/@discordjs/builders": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
-            "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.7.0.tgz",
+            "integrity": "sha512-GDtbKMkg433cOZur8Dv6c25EHxduNIBsxeHrsRoIM8+AwmEZ8r0tEpckx/sHwTLwQPOF3e2JWloZh9ofCaMfAw==",
             "dependencies": {
-                "@discordjs/formatters": "^0.3.2",
-                "@discordjs/util": "^1.0.1",
-                "@sapphire/shapeshift": "^3.9.2",
-                "discord-api-types": "0.37.50",
+                "@discordjs/formatters": "^0.3.3",
+                "@discordjs/util": "^1.0.2",
+                "@sapphire/shapeshift": "^3.9.3",
+                "discord-api-types": "0.37.61",
                 "fast-deep-equal": "^3.1.3",
                 "ts-mixer": "^6.0.3",
-                "tslib": "^2.6.1"
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.11.0"
@@ -775,11 +775,11 @@
             }
         },
         "node_modules/@discordjs/formatters": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
-            "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.3.tgz",
+            "integrity": "sha512-wTcI1Q5cps1eSGhl6+6AzzZkBBlVrBdc9IUhJbijRgVjCNIIIZPgqnUj3ntFODsHrdbGU8BEG9XmDQmgEEYn3w==",
             "dependencies": {
-                "discord-api-types": "0.37.50"
+                "discord-api-types": "0.37.61"
             },
             "engines": {
                 "node": ">=16.11.0"
@@ -869,49 +869,65 @@
             }
         },
         "node_modules/@discordjs/rest": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-            "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.2.0.tgz",
+            "integrity": "sha512-nXm9wT8oqrYFRMEqTXQx9DUTeEtXUDMmnUKIhZn6O2EeDY9VCdwj23XCPq7fkqMPKdF7ldAfeVKyxxFdbZl59A==",
             "dependencies": {
-                "@discordjs/collection": "^1.5.3",
-                "@discordjs/util": "^1.0.1",
+                "@discordjs/collection": "^2.0.0",
+                "@discordjs/util": "^1.0.2",
                 "@sapphire/async-queue": "^1.5.0",
                 "@sapphire/snowflake": "^3.5.1",
                 "@vladfrangu/async_event_emitter": "^2.2.2",
-                "discord-api-types": "0.37.50",
-                "magic-bytes.js": "^1.0.15",
-                "tslib": "^2.6.1",
-                "undici": "5.22.1"
+                "discord-api-types": "0.37.61",
+                "magic-bytes.js": "^1.5.0",
+                "tslib": "^2.6.2",
+                "undici": "5.27.2"
             },
             "engines": {
                 "node": ">=16.11.0"
             }
         },
+        "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
+            "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@discordjs/util": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-            "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.2.tgz",
+            "integrity": "sha512-IRNbimrmfb75GMNEjyznqM1tkI7HrZOf14njX7tCAAUetyZM1Pr8hX/EK2lxBCOgWDRmigbp24fD1hdMfQK5lw==",
             "engines": {
                 "node": ">=16.11.0"
             }
         },
         "node_modules/@discordjs/ws": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
-            "integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.2.tgz",
+            "integrity": "sha512-+XI82Rm2hKnFwAySXEep4A7Kfoowt6weO6381jgW+wVdTpMS/56qCvoXyFRY0slcv7c/U8My2PwIB2/wEaAh7Q==",
             "dependencies": {
-                "@discordjs/collection": "^1.5.3",
-                "@discordjs/rest": "^2.0.1",
-                "@discordjs/util": "^1.0.1",
+                "@discordjs/collection": "^2.0.0",
+                "@discordjs/rest": "^2.1.0",
+                "@discordjs/util": "^1.0.2",
                 "@sapphire/async-queue": "^1.5.0",
-                "@types/ws": "^8.5.5",
+                "@types/ws": "^8.5.9",
                 "@vladfrangu/async_event_emitter": "^2.2.2",
-                "discord-api-types": "0.37.50",
-                "tslib": "^2.6.1",
-                "ws": "^8.13.0"
+                "discord-api-types": "0.37.61",
+                "tslib": "^2.6.2",
+                "ws": "^8.14.2"
             },
             "engines": {
                 "node": ">=16.11.0"
+            }
+        },
+        "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
+            "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -1510,9 +1526,9 @@
             }
         },
         "node_modules/@sapphire/shapeshift": {
-            "version": "3.9.3",
-            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.3.tgz",
-            "integrity": "sha512-WzKJSwDYloSkHoBbE8rkRW8UNKJiSRJ/P8NqJ5iVq7U2Yr/kriIBx2hW+wj2Z5e5EnXL1hgYomgaFsdK6b+zqQ==",
+            "version": "3.9.4",
+            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.4.tgz",
+            "integrity": "sha512-SiOoCBmm8O7QuadLJnX4V0tAkhC54NIOZJtmvw+5zwnHaiulGkjY02wxCuK8Gf4V540ILmGz+UulC0U8mrOZjg==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "lodash": "^4.17.21"
@@ -1747,9 +1763,9 @@
             "dev": true
         },
         "node_modules/@types/ws": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
-            "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
+            "version": "8.5.9",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
+            "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2450,17 +2466,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/busboy": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-            "dependencies": {
-                "streamsearch": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=10.16.0"
-            }
-        },
         "node_modules/cacheable-lookup": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -3053,9 +3058,9 @@
             }
         },
         "node_modules/discord-api-types": {
-            "version": "0.37.50",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-            "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
+            "version": "0.37.61",
+            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
+            "integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
         },
         "node_modules/discord-player": {
             "version": "6.6.6",
@@ -3094,24 +3099,24 @@
             }
         },
         "node_modules/discord.js": {
-            "version": "14.13.0",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
-            "integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
+            "version": "14.14.1",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.14.1.tgz",
+            "integrity": "sha512-/hUVzkIerxKHyRKopJy5xejp4MYKDPTszAnpYxzVVv4qJYf+Tkt+jnT2N29PIPschicaEEpXwF2ARrTYHYwQ5w==",
             "dependencies": {
-                "@discordjs/builders": "^1.6.5",
-                "@discordjs/collection": "^1.5.3",
-                "@discordjs/formatters": "^0.3.2",
-                "@discordjs/rest": "^2.0.1",
-                "@discordjs/util": "^1.0.1",
-                "@discordjs/ws": "^1.0.1",
-                "@sapphire/snowflake": "^3.5.1",
-                "@types/ws": "^8.5.5",
-                "discord-api-types": "0.37.50",
-                "fast-deep-equal": "^3.1.3",
-                "lodash.snakecase": "^4.1.1",
-                "tslib": "^2.6.1",
-                "undici": "5.22.1",
-                "ws": "^8.13.0"
+                "@discordjs/builders": "^1.7.0",
+                "@discordjs/collection": "1.5.3",
+                "@discordjs/formatters": "^0.3.3",
+                "@discordjs/rest": "^2.1.0",
+                "@discordjs/util": "^1.0.2",
+                "@discordjs/ws": "^1.0.2",
+                "@sapphire/snowflake": "3.5.1",
+                "@types/ws": "8.5.9",
+                "discord-api-types": "0.37.61",
+                "fast-deep-equal": "3.1.3",
+                "lodash.snakecase": "4.1.1",
+                "tslib": "2.6.2",
+                "undici": "5.27.2",
+                "ws": "8.14.2"
             },
             "engines": {
                 "node": ">=16.11.0"
@@ -3800,17 +3805,6 @@
             "dependencies": {
                 "node-html-parser": "^6.1.9",
                 "undici": "^5.24.0"
-            }
-        },
-        "node_modules/genius-lyrics/node_modules/undici": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
-            "integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
             }
         },
         "node_modules/gensync": {
@@ -6521,14 +6515,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/streamsearch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6887,11 +6873,11 @@
             }
         },
         "node_modules/undici": {
-            "version": "5.22.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-            "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+            "version": "5.27.2",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
+            "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
             "dependencies": {
-                "busboy": "^1.6.0"
+                "@fastify/busboy": "^2.0.0"
             },
             "engines": {
                 "node": ">=14.0"
@@ -7145,17 +7131,6 @@
             "integrity": "sha512-vyzHSwxlCAwqWUxZKJ/5g139BgnbmZFTy9I0nxDwqlbAh74dB1LjayCoB5BgLaaIkSMruEQwlf5bF+EeR235qA==",
             "dependencies": {
                 "undici": "^5.26.3"
-            }
-        },
-        "node_modules/youtube-ext/node_modules/undici": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
-            "integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
             }
         },
         "node_modules/youtube-sr": {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "dependencies": {
         "@discord-player/extractor": "^4.4.5",
         "@discord-player/opus": "^0.1.2",
-        "@discordjs/rest": "^2.0.0",
+        "@discordjs/rest": "^2.2.0",
         "config": "^3.3.9",
         "discord-player": "^6.6.6",
         "discord-voip": "^0.1.3",
-        "discord.js": "^14.12.1",
+        "discord.js": "^14.14.1",
         "dotenv": "^16.3.1",
         "mediaplex": "^0.0.9",
         "node-os-utils": "^1.3.7",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -38,7 +38,7 @@ const logger: Logger = loggerModule.child({
             client.registerClientInteractions = registerClientInteractions;
             await registerEventListeners({ client, player, executionId });
             await registerClientInteractions({ client, executionId });
-            client.emit('ready', client as Client);
+            client.emit('ready', client as Client<true>);
             allShardsReadyReceived = true;
         });
 


### PR DESCRIPTION
## Changes
- Update `discord.js` to `^14.14.1`, and `@discordjs/rest` to `^2.2.0`
- `npm audit` fix for `undici` related to discordjs.
- Ensure proper typing with `client.emit('ready', client as Client<true>)` after `discord.js` type changes.

### Dependencies
- Update `discord.js` to `^14.14.1`, and `@discordjs/rest` to `^2.2.0`
