### PR TITLE
Move command

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -100,6 +100,7 @@ module.exports.embedOptions = {
         back: '⏮️',
         pauseResumed: '⏯️',
         shuffled: '🔀',
+        moved: '🔀',
         volume: '🔊',
         volumeIsMuted: '🔇',
         volumeChanged: '🔊',

--- a/src/classes/interactions.ts
+++ b/src/classes/interactions.ts
@@ -122,7 +122,7 @@ abstract class BaseInteraction {
             return { text: 'Page 1 of 1 (0 tracks)' };
         }
 
-        const pageIndex: number = (interaction.options.getNumber('page') || 1) - 1;
+        const pageIndex: number = (interaction.options.getInteger('page') || 1) - 1;
         const totalPages: number = Math.ceil(queue.tracks.data.length / 10) || 1;
         return {
             text: `Page ${pageIndex + 1} of ${totalPages} (${queue.tracks.data.length} tracks)`

--- a/src/interactions/commands/player/back.ts
+++ b/src/interactions/commands/player/back.ts
@@ -30,7 +30,7 @@ class BackCommand extends BaseSlashCommandInteraction {
             checkQueueCurrentTrack
         ]);
 
-        const backToTrackInput: number = interaction.options.getNumber('position')!;
+        const backToTrackInput: number = interaction.options.getInteger('position')!;
 
         if (backToTrackInput) {
             return await this.handleBackToTrackPosition(logger, interaction, history, backToTrackInput);

--- a/src/interactions/commands/player/back.ts
+++ b/src/interactions/commands/player/back.ts
@@ -11,7 +11,7 @@ class BackCommand extends BaseSlashCommandInteraction {
         const data = new SlashCommandBuilder()
             .setName('back')
             .setDescription('Go back to previous track or specified position in history.')
-            .addNumberOption((option) =>
+            .addIntegerOption((option) =>
                 option.setName('position').setDescription('The position in history to go back to.').setMinValue(1)
             );
         super(data);

--- a/src/interactions/commands/player/history.ts
+++ b/src/interactions/commands/player/history.ts
@@ -22,7 +22,7 @@ class HistoryCommand extends BaseSlashCommandInteraction {
         const data = new SlashCommandBuilder()
             .setName('history')
             .setDescription('Show history of tracks that have been played.')
-            .addNumberOption((option) =>
+            .addIntegerOption((option) =>
                 option.setName('page').setDescription('Page number to display for the history').setMinValue(1)
             );
         super(data);

--- a/src/interactions/commands/player/history.ts
+++ b/src/interactions/commands/player/history.ts
@@ -182,7 +182,7 @@ class HistoryCommand extends BaseSlashCommandInteraction {
     }
 
     private getPageIndex(interaction: ChatInputCommandInteraction): number {
-        return (interaction.options.getNumber('page') || 1) - 1;
+        return (interaction.options.getInteger('page') || 1) - 1;
     }
 
     private getTotalPages(history: GuildQueueHistory): number {

--- a/src/interactions/commands/player/loop.ts
+++ b/src/interactions/commands/player/loop.ts
@@ -44,7 +44,7 @@ class LoopCommand extends BaseSlashCommandInteraction {
             checkQueueExists
         ]);
 
-        const userInputRepeatMode: QueueRepeatMode = interaction.options.getNumber('mode')!;
+        const userInputRepeatMode: QueueRepeatMode = interaction.options.getInteger('mode')!;
         const currentRepeatMode: QueueRepeatMode = queue.repeatMode;
 
         if (!userInputRepeatMode && userInputRepeatMode !== 0) {

--- a/src/interactions/commands/player/loop.ts
+++ b/src/interactions/commands/player/loop.ts
@@ -4,7 +4,7 @@ import {
     EmbedBuilder,
     Message,
     SlashCommandBuilder,
-    SlashCommandNumberOption
+    SlashCommandIntegerOption
 } from 'discord.js';
 import { Logger } from 'pino';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
@@ -17,8 +17,8 @@ class LoopCommand extends BaseSlashCommandInteraction {
         const data = new SlashCommandBuilder()
             .setName('loop')
             .setDescription('Toggle looping a track, the whole queue or autoplay.')
-            .addNumberOption(() =>
-                new SlashCommandNumberOption()
+            .addIntegerOption(() =>
+                new SlashCommandIntegerOption()
                     .setName('mode')
                     .setDescription('Loop mode: Track, queue, autoplay or disabled.')
                     .setRequired(false)

--- a/src/interactions/commands/player/move.ts
+++ b/src/interactions/commands/player/move.ts
@@ -1,0 +1,116 @@
+import { GuildQueue, Track, useQueue } from 'discord-player';
+import { ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import { BaseSlashCommandInteraction } from '../../../classes/interactions';
+import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
+import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { Logger } from 'pino';
+
+class MoveCommand extends BaseSlashCommandInteraction {
+    constructor() {
+        const data = new SlashCommandBuilder()
+            .setName('move')
+            .setDescription('Move a track to a specified position in queue.')
+            .addIntegerOption((option) =>
+                option
+                    .setName('from')
+                    .setDescription('The position of the track to move')
+                    .setMinValue(1)
+                    .setRequired(true)
+            )
+            .addIntegerOption((option) =>
+                option
+                    .setName('to')
+                    .setDescription('The position to move the track to')
+                    .setMinValue(1)
+                    .setRequired(true)
+            );
+        super(data);
+    }
+
+    async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
+        const { executionId, interaction } = params;
+        const logger = this.getLogger(this.name, executionId, interaction);
+
+        const queue: GuildQueue = useQueue(interaction.guild!.id)!;
+
+        await this.runValidators({ interaction, queue, executionId }, [
+            checkInVoiceChannel,
+            checkSameVoiceChannel,
+            checkQueueExists,
+            checkQueueCurrentTrack
+        ]);
+
+        const fromPositionInput: number = interaction.options.getInteger('from')!;
+        const toPositionInput: number = interaction.options.getInteger('to')!;
+        return await this.handleMoveTrackToPosition(logger, interaction, queue, fromPositionInput, toPositionInput);
+    }
+
+    private async handleMoveTrackToPosition(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        queue: GuildQueue,
+        fromPosition: number,
+        toPosition: number
+    ) {
+        if (fromPosition > queue.tracks.data.length || toPosition > queue.tracks.data.length) {
+            logger.debug('One of the specified track positions was higher than total tracks.');
+            return await this.handleTrackPositionHigherThanQueueLength(
+                fromPosition,
+                toPosition,
+                queue,
+                logger,
+                interaction
+            );
+        } else {
+            const trackToMove: Track = queue.tracks.data[fromPosition - 1];
+            queue.node.move(trackToMove, toPosition - 1);
+            logger.debug(`Moved track from position ${fromPosition} to position ${toPosition} in queue`);
+            return await this.respondWithSuccessEmbed(trackToMove, interaction, fromPosition, toPosition);
+        }
+    }
+
+    private async handleTrackPositionHigherThanQueueLength(
+        fromPosition: number,
+        toPosition: number,
+        queue: GuildQueue,
+        logger: Logger,
+        interaction: ChatInputCommandInteraction
+    ) {
+        logger.debug('One of the specified track positions was higher than total tracks.');
+        return await interaction.editReply({
+            embeds: [
+                new EmbedBuilder()
+                    .setDescription(
+                        `**${this.embedOptions.icons.warning} Oops!**\n` +
+                            `You cannot move track in position **\`${fromPosition}\`** to position **\`${toPosition}\`**. There are only **\`${queue.tracks.data.length}\`** tracks in the queue.\n\n` +
+                            'View tracks added to the queue with **`/queue`**.'
+                    )
+                    .setColor(this.embedOptions.colors.warning)
+            ]
+        });
+    }
+
+    private async respondWithSuccessEmbed(
+        movedTrack: Track,
+        interaction: ChatInputCommandInteraction,
+        fromPosition: number,
+        toPosition: number
+    ) {
+        return await interaction.editReply({
+            embeds: [
+                new EmbedBuilder()
+                    .setAuthor(this.getEmbedUserAuthor(interaction))
+                    .setDescription(
+                        `**${this.embedOptions.icons.moved} Moved track**\n` +
+                            `${this.getDisplayTrackDurationAndUrl(movedTrack)}\n\n` +
+                            `Track has been moved from position **\`${fromPosition}\`** to position **\`${toPosition}\`**.`
+                    )
+                    .setThumbnail(this.getTrackThumbnailUrl(movedTrack))
+                    .setColor(this.embedOptions.colors.success)
+            ]
+        });
+    }
+}
+
+export default new MoveCommand();

--- a/src/interactions/commands/player/queue.ts
+++ b/src/interactions/commands/player/queue.ts
@@ -23,7 +23,7 @@ class QueueCommand extends BaseSlashCommandInteraction {
         const data = new SlashCommandBuilder()
             .setName('queue')
             .setDescription('Show tracks that have been added to the queue.')
-            .addNumberOption((option) =>
+            .addIntegerOption((option) =>
                 option.setName('page').setDescription('Page number to display for the queue').setMinValue(1)
             );
         super(data);

--- a/src/interactions/commands/player/queue.ts
+++ b/src/interactions/commands/player/queue.ts
@@ -173,7 +173,7 @@ class QueueCommand extends BaseSlashCommandInteraction {
     }
 
     private getPageIndex(interaction: ChatInputCommandInteraction): number {
-        return (interaction.options.getNumber('page') || 1) - 1;
+        return (interaction.options.getInteger('page') || 1) - 1;
     }
 
     private getTotalPages(queue: GuildQueue): number {

--- a/src/interactions/commands/player/remove.ts
+++ b/src/interactions/commands/player/remove.ts
@@ -31,12 +31,14 @@ class RemoveCommand extends BaseSlashCommandInteraction {
                         option
                             .setName('start')
                             .setDescription('The starting position of the range to remove')
+                            .setMinValue(1)
                             .setRequired(true)
                     )
                     .addIntegerOption((option) =>
                         option
                             .setName('end')
                             .setDescription('The ending position of the range to remove')
+                            .setMinValue(1)
                             .setRequired(true)
                     )
             )

--- a/src/interactions/commands/player/skip.ts
+++ b/src/interactions/commands/player/skip.ts
@@ -30,7 +30,7 @@ class SkipCommand extends BaseSlashCommandInteraction {
             checkQueueCurrentTrack
         ]);
 
-        const trackPositionInput: number = interaction.options.getNumber('position')!;
+        const trackPositionInput: number = interaction.options.getInteger('position')!;
 
         if (trackPositionInput) {
             return await this.handleSkipToTrackPosition(logger, interaction, queue, trackPositionInput);

--- a/src/interactions/commands/player/skip.ts
+++ b/src/interactions/commands/player/skip.ts
@@ -11,7 +11,7 @@ class SkipCommand extends BaseSlashCommandInteraction {
         const data = new SlashCommandBuilder()
             .setName('skip')
             .setDescription('Skip track to next or specified position in queue.')
-            .addNumberOption((option) =>
+            .addIntegerOption((option) =>
                 option.setName('position').setDescription('The position in queue to skip to.').setMinValue(1)
             );
         super(data);

--- a/src/interactions/commands/player/volume.ts
+++ b/src/interactions/commands/player/volume.ts
@@ -11,7 +11,7 @@ class VolumeCommand extends BaseSlashCommandInteraction {
         const data = new SlashCommandBuilder()
             .setName('volume')
             .setDescription('Show or change the playback volume for tracks.')
-            .addNumberOption((option) =>
+            .addIntegerOption((option) =>
                 option
                     .setName('percentage')
                     .setDescription('Volume percentage: From 1% to 100%.')

--- a/src/interactions/commands/player/volume.ts
+++ b/src/interactions/commands/player/volume.ts
@@ -33,7 +33,7 @@ class VolumeCommand extends BaseSlashCommandInteraction {
             checkQueueExists
         ]);
 
-        const volume: number = interaction.options.getNumber('percentage')!;
+        const volume: number = interaction.options.getInteger('percentage')!;
 
         if (!volume && volume !== 0) {
             return await this.handleShowCurrentVolume(queue, logger, interaction);

--- a/src/interactions/commands/system/shards.ts
+++ b/src/interactions/commands/system/shards.ts
@@ -31,7 +31,7 @@ class ShardsCommand extends BaseSlashCommandInteraction {
                         { name: 'Members', value: 'members' }
                     )
             )
-            .addNumberOption((option) =>
+            .addIntegerOption((option) =>
                 option.setName('page').setDescription('Page number to display for the shards').setMinValue(1)
             );
         const isSystemCommand: boolean = true;

--- a/src/interactions/commands/system/shards.ts
+++ b/src/interactions/commands/system/shards.ts
@@ -189,7 +189,7 @@ class ShardsCommand extends BaseSlashCommandInteraction {
     }
 
     private getPageIndex(interaction: ChatInputCommandInteraction): number {
-        return (interaction.options.getNumber('page') || 1) - 1;
+        return (interaction.options.getInteger('page') || 1) - 1;
     }
 
     private getTotalPages(shardCount: number): number {

--- a/src/types/configTypes.d.ts
+++ b/src/types/configTypes.d.ts
@@ -74,6 +74,7 @@ export type EmbedOptions = {
         back: string;
         pauseResumed: string;
         shuffled: string;
+        moved: string;
         volume: string;
         volumeIsMuted: string;
         volumeChanged: string;


### PR DESCRIPTION
## Changes
- New /move command to move a track to another position in queue. Usage: /move from to
- Updated usage of addNumberOption to addIntegerOption where values should be integers across interactions.

### Dependencies
- No changes