### PR TITLE
Localization support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "ignorePatterns": ["config/**/*.js"],
+    "ignorePatterns": ["config/**/*.js", "locales/**"],
     "env": {
         "node": true,
         "es2021": true

--- a/README.md
+++ b/README.md
@@ -21,13 +21,16 @@
 </p>
 
 ## Core Features 🌟
+
 Cadence offers an enriching audio experience on Discord with features such as:
-- High-quality music playback from [many supported sources](https://discord-player.js.org/guide/extractors/stream-sources) thanks to [discord-player](https://github.com/androz2091/discord-player).
-- Slash commands, autocompleting search queries, select menus, buttons and more interactive features!
-- Full queue management system to add, remove, skip or move tracks, view queue and history.
-- Audio filters, shuffle mode, repeat track, queue or autoplay similar tracks!
-- Open-source codebase and community based development, open to feedback and improvements.
-- No locked functionality, no premium tier, no ads; everything's free, always.
+
+-   High-quality music playback from [many supported sources](https://discord-player.js.org/guide/extractors/stream-sources) thanks to [discord-player](https://github.com/androz2091/discord-player).
+-   Slash commands, autocompleting search queries, select menus, buttons and more interactive features!
+-   Full queue management system to add, remove, skip or move tracks, view queue and history.
+-   Audio filters, shuffle mode, repeat track, queue or autoplay similar tracks!
+-   Localization with support for multiple languages both for Slash Commands and embed replies.
+-   Open-source codebase and community based development, open to feedback and improvements.
+-   No locked functionality, no premium tier, no ads; everything's free, always.
 
 <br>
 
@@ -54,10 +57,10 @@ Cadence offers an enriching audio experience on Discord with features such as:
 
 ### Configuration and Logging:
 
-- Override default configuration by creating `/config/local.js`.
-- Use `npm run deploy-pretty` and `npm run start-pretty` for better console output, requires [pino-pretty](https://www.npmjs.com/package/pino-pretty).
-- Logs are stored in `/logs` folder. Configure the logging level in the config file.
-- For production, usage of `pm2` or similar to manage the bot process is recommended.
+-   Override default configuration by creating `/config/local.js`.
+-   Use `npm run deploy-pretty` and `npm run start-pretty` for better console output, requires [pino-pretty](https://www.npmjs.com/package/pino-pretty).
+-   Logs are stored in `/logs` folder. Configure the logging level in the config file.
+-   For production, usage of `pm2` or similar to manage the bot process is recommended.
 
 <br>
 

--- a/config/default.js
+++ b/config/default.js
@@ -89,6 +89,7 @@ module.exports.embedOptions = {
         nextTrack: '⏭️',
         previousTrack: '⏮️',
         pauseResumeTrack: '⏯️',
+        paused: '⏸',
         shuffleQueue: '🔀',
         loop: '🔁',
         loopAction: '🔁',

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -26,7 +26,13 @@
                 "options": {
                     "type": {
                         "name": "type",
-                        "description": "Audio filter type to use."
+                        "description": "Audio filter type to use.",
+                        "choices": {
+                            "ffmpeg": "FFmpeg",
+                            "biquad": "Biquad",
+                            "equalizer": "Equalizer",
+                            "disable": "Disable"
+                        }
                     }
                 }
             },
@@ -93,7 +99,13 @@
                 "options": {
                     "mode": {
                         "name": "mode",
-                        "description": "Loop mode: Track, queue, autoplay or disabled."
+                        "description": "Loop mode: Track, queue, autoplay or disabled.",
+                        "choices": {
+                            "0": "Off",
+                            "1": "Track",
+                            "2": "Queue",
+                            "3": "Autoplay"
+                        }
                     }
                 }
             },
@@ -102,13 +114,7 @@
             "modeChanged": "{{icon}} **Loop mode changed**\nChanging loop mode from **`{{fromName}}`** to **`{{toName}}`**.",
             "willAutoplay": "When the queue is empty, similar tracks will start playing!",
             "willNoLongerPlay": "The {{mode}} will no longer play on repeat!",
-            "willNowPlay": "The {{mode}} will now play on repeat!",
-            "repeatMode": {
-                "off": "disabled",
-                "track": "track",
-                "queue": "queue",
-                "autoplay": "autoplay"
-            }
+            "willNowPlay": "The {{mode}} will now play on repeat!"
         },
         "lyrics": {
             "metadata": {
@@ -148,7 +154,16 @@
             "metadata": {
                 "name": "nowplaying",
                 "description": "Show information about the current track."
-            }
+            },
+            "embedFields": {
+                "author": "**Artist**",
+                "plays": "**Plays**",
+                "source": "**Track source**"
+            },
+            "otherTracksInQueue_one": "1 other track in the queue...",
+            "otherTracksInQueue": "{{count}} other tracks in the queue...",
+            "playCount_zero": "Unknown",
+            "playCount": "{{count, number}}"
         },
         "pause": {
             "metadata": {
@@ -156,7 +171,8 @@
                 "description": "Toggle pause for the current track."
             },
             "pauseConfirmation": "{{icon}} **Paused track**",
-            "resumeConfirmation": "{{icon}} **Resumed track**"
+            "resumeConfirmation": "{{icon}} **Resumed track**",
+            "directSource": "Direct source"
         },
         "play": {
             "metadata": {
@@ -227,7 +243,16 @@
                 "options": {
                     "sort": {
                         "name": "sort",
-                        "description": "What to sort the shards by."
+                        "description": "What to sort the shards by.",
+                        "choices": {
+                            "none": "None (Shard ID)",
+                            "memory": "Memory usage",
+                            "connections": "Voice Connections",
+                            "tracks": "Tracks",
+                            "listeners": "Listeners",
+                            "guilds": "Guilds",
+                            "members": "Members"
+                        }
                     },
                     "page": {
                         "name": "page",
@@ -306,13 +331,22 @@
         "footerPageNumber_one": "Page {{page}} of {{pageCount}} (1 track)",
         "footerPageNumber": "Page {{page}} of {{pageCount}} ({{count}} tracks)",
         "loopingInfo": "{{icon}} **Looping**\nLoop mode is set to **`{{loopMode}}`**. You can change it with {{loopCommand}}.",
+        "nowPausedTitle": "{{icon}} **Currently paused**",
         "nowPlayingTitle": "{{icon}} **Now playing**",
         "playingLive": "{{icon}} **`LIVE`** - Playing continuously from live source.",
+        "queueRepeatMode": {
+            "off": "Disabled",
+            "track": "Track",
+            "queue": "Queue",
+            "autoplay": "Autoplay"
+        },
         "requestedBy": "**Requested by:** {{user}}",
+        "unavailableAuthor": "Unavailable",
         "unavailableDuration": "_No duration available._",
         "unavailableRequestedBy": "Unavailable",
         "unavailableTrackTitle": "Title unavailable",
         "unavailableTrackUrl": "**Unavailable**",
+        "unavailableSource": "Unavailable",
         "voiceChannelInfo": "Channel: {{channel}} ({{bitrate}}kbps)"
     },
     "statistics": {

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -72,8 +72,8 @@
                 }
             },
             "emptyHistory": "The history is empty, add some tracks with {{playCommand}}!",
-            "invalidPageNumber_one": "{{icon}} **Oops!**\nPage **{{page}}** is not a valid page number.\n\nThere is only **`1`** page in the history.",
-            "invalidPageNumber": "{{icon}} **Oops!**\nPage **{{page}}** is not a valid page number.\n\nThere are only a total of **`{{count}}`** pages in the history.",
+            "invalidPageNumber_one": "{{icon}} **Oops!**\nPage **`{{page}}`** is not a valid page number.\n\nThere is only **`1`** page in the history.",
+            "invalidPageNumber": "{{icon}} **Oops!**\nPage **`{{page}}`** is not a valid page number.\n\nThere are only a total of **`{{count}}`** pages in the history.",
             "tracksInHistoryTitle": "{{icon}} **Tracks in history**"
         },
         "join": {
@@ -203,7 +203,12 @@
                     }
                 }
             },
-            "tracksInQueueTitle": "{{icon}} **Tracks in queue**"
+            "tracksInQueueTitle": "{{icon}} **Tracks in queue**",
+            "emptyQueue": "The queue is empty, add some tracks with {{playCommand}}!",
+            "estimatedDuration": "Estimated duration: {{duration}}",
+            "estimatedReallyLongTime": "Estimated duration: A really long time",
+            "invalidPageNumber_one": "{{icon}} **Oops!**\nPage **`{{page}}`** is not a valid page number.\n\nThere is only **`1`** page in the queue.",
+            "invalidPageNumber": "{{icon}} **Oops!**\nPage **`{{page}}`** is not a valid page number.\n\nThere are only a total of **`{{count}}`** pages in the queue."
         },
         "reload": {
             "metadata": {

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -56,9 +56,9 @@
                 "name": "help",
                 "description": "Show the list of bot commands."
             },
-            "addBotCallout": "{{icon}} **Enjoying {{botName}}?**\nAdd me to another server:\n**[Click me!]({{invite}})**",
+            "addBotButton": "Add bot",
             "listTitle": "{{icon}} **List of commands**",
-            "supportServerCallout": "{{icon}} **Support server**\nJoin the support server for help or to suggest improvements:\n{{invite}}"
+            "supportServerButton": "Support server"
         },
         "history": {
             "metadata": {

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -31,7 +31,7 @@
                             "ffmpeg": "FFmpeg",
                             "biquad": "Biquad",
                             "equalizer": "Equalizer",
-                            "disable": "Disable"
+                            "disable": "Disabled"
                         }
                     }
                 }
@@ -224,7 +224,7 @@
         "seek": {
             "metadata": {
                 "name": "seek",
-                "description": "Seek to a position in the current track.",
+                "description": "Seek to a time position in the current track.",
                 "options": {
                     "duration": {
                         "name": "duration",

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -325,6 +325,12 @@
             "volumeMuted": "{{icon}} **Audio muted**\nPlayback audio has been muted, because the volume was set to **`0%`**."
         }
     },
+    "components": {
+        "responses": {
+            "paused": "Paused track",
+            "resumed": "Resumed track"
+        }
+    },
     "musicPlayerCommon": {
         "controls": {
             "stop": "Stop",
@@ -397,6 +403,7 @@
         "notValidGuildId": "{{icon}} **Oops!**\nNo permission to perform this action.\n\nThe command {{command}} cannot be executed in this server.",
         "queueDoesNotExist": "{{icon}} **Oops!**\nThere are no tracks in the queue and nothing currently playing. First add some tracks with {{playCommand}}!",
         "queueIsEmpty": "{{icon}} **Oops!\nThere are no tracks added to the queue. First add some tracks with {{playCommand}}!",
-        "queueNoCurrentTrack": "{{icon}} **Oops!**\nThere is nothing currently playing. First add some tracks with {{playCommand}}!"
+        "queueNoCurrentTrack": "{{icon}} **Oops!**\nThere is nothing currently playing. First add some tracks with {{playCommand}}!",
+        "trackNotPlayingAnymore": "{{icon}} **Oops!**\nThis track has been skipped or is no longer playing."
     }
 }

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -330,7 +330,7 @@
         },
         "footerPageNumber_one": "Page {{page}} of {{pageCount}} (1 track)",
         "footerPageNumber": "Page {{page}} of {{pageCount}} ({{count}} tracks)",
-        "loopingInfo": "{{icon}} **Looping**\nLoop mode is set to **`{{loopMode}}`**. You can change it with {{loopCommand}}.",
+        "loopingInfo": "{{icon}} **Looping**\nLoop mode is set to **`{{loopMode}}`**. You can change it with {{loopCommand}}.\n",
         "nowPausedTitle": "{{icon}} **Currently paused**",
         "nowPlayingTitle": "{{icon}} **Now playing**",
         "playingLive": "{{icon}} **`LIVE`** - Playing continuously from live source.",

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -13,7 +13,11 @@
                         "description": "The position in history to go back to."
                     }
                 }
-            }
+            },
+            "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
+            "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
+            "trackHistoryEmpty": "{{icon}} **Oops!**\nThe history is empty, add some tracks with {{playCommand}}!",
+            "trackRecovered": "{{icon}} **Recovered track**\n{{track}}"
         },
         "filters": {
             "metadata": {

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -3,19 +3,227 @@
         "trackName": "{{title}} [Author: {{author}}]"
     },
     "commands": {
+        "back": {
+            "metadata": {
+                "name": "back",
+                "description": "Go back to previous track or specified position in history.",
+                "options": {
+                    "position": {
+                        "name": "position",
+                        "description": "The position in history to go back to."
+                    }
+                }
+            }
+        },
+        "filters": {
+            "metadata": {
+                "name": "filters",
+                "description": "Toggle various audio filters.",
+                "options": {
+                    "type": {
+                        "name": "type",
+                        "description": "Audio filter type to use."
+                    }
+                }
+            }
+        },
+        "guilds": {
+            "metadata": {
+                "name": "guilds",
+                "description": "Show the top 25 guilds by member count."
+            }
+        },
+        "help": {
+            "metadata": {
+                "name": "help",
+                "description": "Show the list of bot commands."
+            },
+            "listTitle": "{{icon}} **List of commands**",
+            "supportServerCallout": "{{icon}} **Support server**\nJoin the support server for help or to suggest improvements:\n{{invite}}",
+            "addBotCallout": "{{icon}} **Enjoying {{botName}}?**\nAdd me to another server:\n**[Click me!]({{invite}})**"
+        },
+        "history": {
+            "metadata": {
+                "name": "history",
+                "description": "Show history of tracks that have been played.",
+                "options": {
+                    "page": {
+                        "name": "page",
+                        "description": "Page number to display for the history."
+                    }
+                }
+            }
+        },
+        "join": {
+            "metadata": {
+                "name": "join",
+                "description": "The bot will join the voice channel if not already in one."
+            }
+        },
+        "leave": {
+            "metadata": {
+                "name": "leave",
+                "description": "Clear the queue and remove bot from voice channel."
+            }
+        },
+        "loop": {
+            "metadata": {
+                "name": "loop",
+                "description": "Toggle looping a track, the whole queue or autoplay.",
+                "options": {
+                    "mode": {
+                        "name": "mode",
+                        "description": "Loop mode: Track, queue, autoplay or disabled."
+                    }
+                }
+            }
+        },
         "lyrics": {
             "metadata": {
-                "description": "Search Genius lyrics for current or specified track. TEST",
                 "name": "lyrics",
+                "description": "Search Genius lyrics for current or specified track.",
                 "options": {
                     "query": {
                         "name": "query",
-                        "description": "Search query by text or URL. TEST"
+                        "description": "Search query by text or URL."
                     }
                 }
             },
             "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]"
         },
-        "help": {}
+        "move": {
+            "metadata": {
+                "name": "move",
+                "description": "Move a track to a specified position in queue.",
+                "options": {
+                    "from": {
+                        "name": "from",
+                        "description": "The position of the track to move."
+                    },
+                    "to": {
+                        "name": "to",
+                        "description": "The position to move the track to."
+                    }
+                }
+            }
+        },
+        "nowplaying": {
+            "metadata": {
+                "name": "nowplaying",
+                "description": "Show information about the current track."
+            }
+        },
+        "pause": {
+            "metadata": {
+                "name": "pause",
+                "description": "Toggle pause for the current track."
+            }
+        },
+        "play": {
+            "metadata": {
+                "name": "play",
+                "description": "Add a track or playlist to the queue by search query or URL.",
+                "options": {
+                    "query": {
+                        "name": "query",
+                        "description": "Search query by text or URL."
+                    }
+                }
+            }
+        },
+        "queue": {
+            "metadata": {
+                "name": "queue",
+                "description": "Show tracks that have been added to the queue.",
+                "options": {
+                    "page": {
+                        "name": "page",
+                        "description": "Page number to display for the queue."
+                    }
+                }
+            }
+        },
+        "reload": {
+            "metadata": {
+                "name": "reload",
+                "description": "Reload slash command, autocomplete and component interactions across shards."
+            }
+        },
+        "seek": {
+            "metadata": {
+                "name": "seek",
+                "description": "Seek to a position in the current track.",
+                "options": {
+                    "duration": {
+                        "name": "duration",
+                        "description": "Duration in format 00:00:00 (HH:mm:ss)."
+                    }
+                }
+            }
+        },
+        "shards": {
+            "metadata": {
+                "name": "shards",
+                "description": "Show information about all connected shards.",
+                "options": {
+                    "sort": {
+                        "name": "sort",
+                        "description": "What to sort the shards by."
+                    },
+                    "page": {
+                        "name": "page",
+                        "description": "Page number to display for the shards."
+                    }
+                }
+            }
+        },
+        "shuffle": {
+            "metadata": {
+                "name": "shuffle",
+                "description": "Randomly shuffle all tracks in the queue."
+            }
+        },
+        "skip": {
+            "metadata": {
+                "name": "skip",
+                "description": "Skip track to next or specified position in queue.",
+                "options": {
+                    "position": {
+                        "name": "position",
+                        "description": "The position in queue to skip to."
+                    }
+                }
+            }
+        },
+        "status": {
+            "metadata": {
+                "name": "status",
+                "description": "Show operational status of the bot."
+            }
+        },
+        "stop": {
+            "metadata": {
+                "name": "stop",
+                "description": "Clear the queue and stop playing audio."
+            }
+        },
+        "systemstatus": {
+            "metadata": {
+                "name": "systemstatus",
+                "description": "Show operational status of the bot with additional technical information."
+            }
+        },
+        "volume": {
+            "metadata": {
+                "name": "volume",
+                "description": "Show or change the playback volume for tracks.",
+                "options": {
+                    "percentage": {
+                        "name": "percentage",
+                        "description": "Volume percentage: From 1% to 100%."
+                    }
+                }
+            }
+        }
     }
 }

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -14,9 +14,9 @@
                     }
                 }
             },
-            "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
-            "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
             "trackHistoryEmpty": "{{icon}} **Oops!**\nThe history is empty, add some tracks with {{playCommand}}!",
+            "trackPositionHigherThanHistoryLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
+            "trackPositionHigherThanHistoryLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
             "trackRecovered": "{{icon}} **Recovered track**\n{{track}}"
         },
         "filters": {
@@ -30,8 +30,9 @@
                     }
                 }
             },
-            "disableAllFiltersButton": "Disable all filters",
             "allFiltersDisabled": "{{icon}} **Disabled filters**\nAll audio filters have been disabled.",
+            "disableAllFiltersButton": "Disable all filters",
+            "nowUsingFilters": "{{icon}} **Filters toggled**\nNow using these {{mode}} filters:",
             "selectFilterPlaceholder": "Select a filter from the menu.",
             "selectFilterPlaceholderMany": "Select one or multiple filters.",
             "toggleFilterInstructions": "**Toggle filters ({{provider}})**\nEnable or disable audio filters for playback from the menu."
@@ -40,16 +41,18 @@
             "metadata": {
                 "name": "guilds",
                 "description": "Show the top 25 guilds by member count."
-            }
+            },
+            "topGuildsByMemberCount": "{{icon}} **Top {{count}} guilds by member count ({{totalCount}} total)**",
+            "totalMembers": "**Total members:** **`{{count}`**"
         },
         "help": {
             "metadata": {
                 "name": "help",
                 "description": "Show the list of bot commands."
             },
+            "addBotCallout": "{{icon}} **Enjoying {{botName}}?**\nAdd me to another server:\n**[Click me!]({{invite}})**",
             "listTitle": "{{icon}} **List of commands**",
-            "supportServerCallout": "{{icon}} **Support server**\nJoin the support server for help or to suggest improvements:\n{{invite}}",
-            "addBotCallout": "{{icon}} **Enjoying {{botName}}?**\nAdd me to another server:\n**[Click me!]({{invite}})**"
+            "supportServerCallout": "{{icon}} **Support server**\nJoin the support server for help or to suggest improvements:\n{{invite}}"
         },
         "history": {
             "metadata": {
@@ -61,19 +64,27 @@
                         "description": "Page number to display for the history."
                     }
                 }
-            }
+            },
+            "emptyHistory": "The history is empty, add some tracks with {{playCommand}}!",
+            "invalidPageNumber_one": "{{icon}} **Oops!**\nPage **{{page}}** is not a valid page number.\n\nThere is only **`1`** page in the history.",
+            "invalidPageNumber": "{{icon}} **Oops!**\nPage **{{page}}** is not a valid page number.\n\nThere are only a total of **`{{count}}`** pages in the history.",
+            "tracksInHistoryTitle": "{{icon}} **Tracks in history**"
         },
         "join": {
             "metadata": {
                 "name": "join",
                 "description": "The bot will join the voice channel if not already in one."
-            }
+            },
+            "alreadyConnected": "{{icon}} **Oops!**\nI am already connected to the {{channel}} voice channel.\n\nTo disconnect me from the channel, use the {{leaveCommand}} command.",
+            "couldNotJoin": "{{icon}} **Oops!**\nCould not join voice channel, please try again.",
+            "joinedChannel": "{{icon}} **Joined channel**\nConnected to voice channel: {{channel}}\n\nTo add tracks, use the {{playCommand}} command!"
         },
         "leave": {
             "metadata": {
                 "name": "leave",
                 "description": "Clear the queue and remove bot from voice channel."
-            }
+            },
+            "leavingChannel": "{{icon}} **Leaving channel**\nCleared the track queue and left voice channel.\n\nTo play more music, use the {{playCommand}} command!"
         },
         "loop": {
             "metadata": {
@@ -85,6 +96,18 @@
                         "description": "Loop mode: Track, queue, autoplay or disabled."
                     }
                 }
+            },
+            "alreadySet": "{{icon}} **Oops!**\nLoop mode is already **`{{mode}}`**.",
+            "loopModeInformation": "{{icon}} **Current loop mode**\nThe looping mode is currently set to **`{{mode}}`**.",
+            "modeChanged": "{{icon}} **Loop mode changed**\nChanging loop mode from **`{{fromName}}`** to **`{{toName}}`**.",
+            "willAutoplay": "When the queue is empty, similar tracks will start playing!",
+            "willNoLongerPlay": "The {{mode}} will no longer play on repeat!",
+            "willNowPlay": "The {{mode}} will now play on repeat!",
+            "repeatMode": {
+                "off": "disabled",
+                "track": "track",
+                "queue": "queue",
+                "autoplay": "autoplay"
             }
         },
         "lyrics": {
@@ -98,7 +121,9 @@
                     }
                 }
             },
-            "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]"
+            "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]",
+            "lyricsEmbed": "{{icon}} **Showing lyrics**\n**Track: [{{trackTitle}}]({{trackUrl}})**\n**Artist: [{{artistName}}]({{artistUrl}})**",
+            "noLyricsFound": "{{icon}} **No lyrics found**\nThere were no Genius lyrics found for track **{{query}}**."
         },
         "move": {
             "metadata": {
@@ -114,7 +139,10 @@
                         "description": "The position to move the track to."
                     }
                 }
-            }
+            },
+            "trackMoved": "{{icon}} **Moved track**\n{track}\n\nTrack has been moved from position **`{{fromPosition}}`** to position **`{{toPosition}}`**.",
+            "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nYou cannot move the track in position **`{{fromPosition}}`** to position **`{{toPosition}}`**. There is only **`1`** track in the queue.\n\nView tracks added to the queue with {{queueCommand}}.",
+            "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nYou cannot move the track in position **`{{fromPosition}}`** to position **`{{toPosition}}`**. There are only **`{{count}}`** tracks in the queue.\n\nView tracks added to the queue with {{queueCommand}}."
         },
         "nowplaying": {
             "metadata": {
@@ -126,7 +154,9 @@
             "metadata": {
                 "name": "pause",
                 "description": "Toggle pause for the current track."
-            }
+            },
+            "pauseConfirmation": "{{icon}} **Paused track**",
+            "resumeConfirmation": "{{icon}} **Resumed track**"
         },
         "play": {
             "metadata": {
@@ -138,7 +168,13 @@
                         "description": "Search query by text or URL."
                     }
                 }
-            }
+            },
+            "addedToQueueTitle": "{{icon}} **Added to queue**",
+            "playlistAddedTitle": "{{icon}} **Added playlist to queue**",
+            "playlistAddedTrackCount_one": "And **1** more track... Use {{queueCommand}} to view all.",
+            "playlistAddedTrackCount": "And **{{count}}** more tracks... Use {{queueCommand}} to view all.",
+            "playlistTooLarge": "{{icon}} **Playlist too large**\nThis playlist is too large to be added to the queue.\n\nThe maximum amount of tracks that can be added to the queue is **{{count}}**.",
+            "trackNotFound": "{{icon}} **No track found\nNo results found for **{{query}}**.\n\nIf you specified a URL, please make sure it is valid and public."
         },
         "queue": {
             "metadata": {
@@ -150,13 +186,24 @@
                         "description": "Page number to display for the queue."
                     }
                 }
-            }
+            },
+            "tracksInQueueTitle": "{{icon}} **Tracks in queue**"
         },
         "reload": {
             "metadata": {
                 "name": "reload",
                 "description": "Reload slash command, autocomplete and component interactions across shards."
-            }
+            },
+            "reloadedCommands": "{{icon}} **Reloaded commands**",
+            "unableToReload": "{{icon}} **Oops!**\n_Hmm..._ It seems I am unable to reload the interaction module across shards."
+        },
+        "remove": {
+            "noTracksRemoved": "{{icon}} **No tracks removed**\nThere were no tracks removed from the queue. Please check if the option you selected has tracks to remove.",
+            "removedTrack": "{{icon}} **Removed track**",
+            "removedTracks": "{{icon}} **Removed tracks**\n**`{{count}}`** tracks were removed from the queue.",
+            "startPositionHigherThanEndPosition": "{{icon}} **Oops!**\nStart position **`{{start}}`** is higher than end position **`{{end}}`**. Please specify a valid range.\n\nView tracks added to the queue with {{queueCommand}}.",
+            "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nPosition **`{{position}}`** is not a valid track position. There is only a total of **`1`** track in the queue.\n\nView the tracks added to the queue with {{queueCommand}}.",
+            "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nPosition **`{{position}}`** is not a valid track position. There are only a total of **`{{count}}`** tracks in the queue.\n\nView the tracks added to the queue with {{queueCommand}}."
         },
         "seek": {
             "metadata": {
@@ -165,10 +212,13 @@
                 "options": {
                     "duration": {
                         "name": "duration",
-                        "description": "Duration in format 00:00:00 (HH:mm:ss)."
+                        "description": "Timestamp in format 00:00:00 (HH:mm:ss)."
                     }
                 }
-            }
+            },
+            "correctFormatInstruction": "{{icon}} **Oops!**\nYou entered an invalid duration format, **`{{wrongDuration}}`**.\nPlease use the format **`HH:mm:ss`**, **`mm:ss`** or **`ss`**.\n\n**Examples:**\n- **`/seek`** **`1:24:12`** - Seek to 1 hour, 24 minutes and 12 seconds.\n- **`/seek`** **`3:27`** - Seek to 3 minutes and 27 seconds.\n- **`/seek`** **`42`** - Seek to 42 seconds.",
+            "durationLongerThanTrackDuration": "{{icon}} **Oops!**\nYou entered **`{{wrongDuration}}`**, which is a timestamp longer than the duration of the current track.\n\nPlease try a timestamp that is less than the duration of the track (**{{trackDuration}}**).",
+            "seekingToTimestamp": "{{icon}} **Seeking to timestamp**\nSeeking to **`{{duration}}`** in current track."
         },
         "shards": {
             "metadata": {
@@ -190,7 +240,8 @@
             "metadata": {
                 "name": "shuffle",
                 "description": "Randomly shuffle all tracks in the queue."
-            }
+            },
+            "shuffledTracks": "{{icon}} **Shuffled queue tracks**\nThe **{{count}}** tracks in the queue have been shuffled.\n\nView the new queue order with {{queueCommand}}."
         },
         "skip": {
             "metadata": {
@@ -202,7 +253,11 @@
                         "description": "The position in queue to skip to."
                     }
                 }
-            }
+            },
+            "emptyQueue": "{{icon}} **Oops!**\nThe queue is empty, add some tracks with {{playCommand}}!",
+            "skippedTrack": "{{icon}} **Skipped track**",
+            "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the queue. You cannot skip to track **{{position}}**.\n\nView tracks added to the queue with {{queueCommand}}.",
+            "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the queue. You cannot skip to track **{{position}}**.\n\nView tracks added to the queue with {{queueCommand}}."
         },
         "status": {
             "metadata": {
@@ -214,7 +269,8 @@
             "metadata": {
                 "name": "stop",
                 "description": "Clear the queue and stop playing audio."
-            }
+            },
+            "stoppedPlaying": "{{icon}} **Stopped playing**\nStopped playing the audio and cleared the track queue.\n\nTo play more music, use the {{playCommand}} command!"
         },
         "systemstatus": {
             "metadata": {
@@ -232,8 +288,32 @@
                         "description": "Volume percentage: From 1% to 100%."
                     }
                 }
-            }
+            },
+            "invalidVolumeRange": "{{icon}} **Oops!**\nYou cannot set the volume to **`{{wrongVolume}}%`**, please pick a value between **`1%`** and **`100%`**.",
+            "volumeChanged": "{{icon}} **Volume changed**\nPlayback volume has been changed to **`{{volume}}%`**.",
+            "volumeInformation": "{{icon}} **Playback volume**\nThe playback volume is currently set to **`{{volume}}`**.",
+            "volumeMuted": "{{icon}} **Audio muted**\nPlayback audio has been muted, because the volume was set to **`0%`**."
         }
+    },
+    "musicPlayerCommon": {
+        "controls": {
+            "stop": "Stop",
+            "previous": "Previous",
+            "pause": "Pause",
+            "resume": "Resume",
+            "skip": "Skip"
+        },
+        "footerPageNumber_one": "Page {{page}} of {{pageCount}} (1 track)",
+        "footerPageNumber": "Page {{page}} of {{pageCount}} ({{count}} tracks)",
+        "loopingInfo": "{{icon}} **Looping**\nLoop mode is set to **`{{loopMode}}`**. You can change it with {{loopCommand}}.",
+        "nowPlayingTitle": "{{icon}} **Now playing**",
+        "playingLive": "{{icon}} **`LIVE`** - Playing continuously from live source.",
+        "requestedBy": "**Requested by:** {{user}}",
+        "unavailableDuration": "_No duration available._",
+        "unavailableRequestedBy": "Unavailable",
+        "unavailableTrackTitle": "Title unavailable",
+        "unavailableTrackUrl": "**Unavailable**",
+        "voiceChannelInfo": "Channel: {{channel}} ({{bitrate}}kbps)"
     },
     "statistics": {
         "botStatus": {
@@ -268,5 +348,16 @@
         "dependencies": {
             "title": "{{icon}} **Dependencies**"
         }
+    },
+    "validation": {
+        "cannotJoinVoiceOrTalk": "{{icon}} **Oops!**\nI do not have permission to play audio in the voice channel {{channel}}.\n\nPlease make sure I have the **`Connect`** and **`Speak`** permissions in this voice channel.",
+        "cannotSendMessageInChannel": "{{icon}} **Oops!**\nI do not have permission to send message replies in the channel {{channel}}.\n\nPlease make sure I have the **`View Channel`** permission in this text channel.",
+        "historyDoesNotExist": "{{icon}} **Oops!**\nThere are no tracks in the history and nothing currently playing. First add some tracks with {{playCommand}}!",
+        "notInSameVoiceChannel": "{{icon}} **Not in same voice channel**\nYou need to be in the same voice channel as me to perform this action.\n\n**Voice channel:** {{channel}}",
+        "notInVoiceChannel": "{{icon}} **Not in a voice channel**\nYou need to be in a voice channel to perform this action.",
+        "notValidGuildId": "{{icon}} **Oops!**\nNo permission to perform this action.\n\nThe command {{command}} cannot be executed in this server.",
+        "queueDoesNotExist": "{{icon}} **Oops!**\nThere are no tracks in the queue and nothing currently playing. First add some tracks with {{playCommand}}!",
+        "queueIsEmpty": "{{icon}} **Oops!\nThere are no tracks added to the queue. First add some tracks with {{playCommand}}!",
+        "queueNoCurrentTrack": "{{icon}} **Oops!**\nThere is nothing currently playing. First add some tracks with {{playCommand}}!"
     }
 }

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -225,5 +225,39 @@
                 }
             }
         }
+    },
+    "statistics": {
+        "botStatus": {
+            "title": "{{icon}} **Bot status**",
+            "joinedServers": "**{{count}}** Joined servers",
+            "joinedServers_one": "**1** Joined server",
+            "totalMembers": "**{{count}}** Total members",
+            "releaseVersion": "**{{version}}** Release version"
+        },
+        "queueStatus": {
+            "title": "{{icon}} **Queue status**",
+            "voiceConnections": "**{{count}}** Voice connections",
+            "voiceConnections_one": "**1** Voice connection",
+            "tracksInQueues": "**{{count}}** Tracks in queues",
+            "tracksInQueues_one": "**1** Track in queues",
+            "usersListening": "**{{count}}** Users listening",
+            "usersListening_one": "**1** User listening"
+        },
+        "systemStatus": {
+            "title": "{{icon}} **System status**",
+            "uptime": "**{{value}}** Uptime",
+            "cpu": "**{{value, number(minimumFractionDigits: 2)}}%** CPU usage",
+            "cpuDetailed": "**{{usage}}% @ {{cores}} cores** CPU usage",
+            "memory": "**{{value, number}} MB** Memory usage",
+            "memoryDetailed": "**{{used, number}} / {{total, number}} MB** Memory usage",
+            "platform": "**{{value}}** Platform"
+        },
+        "discordStatus": {
+            "title": "{{icon}} **Discord status**",
+            "apiLatency": "**{{value, number}} ms** Discord API latency"
+        },
+        "dependencies": {
+            "title": "{{icon}} **Dependencies**"
+        }
     }
 }

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -29,7 +29,12 @@
                         "description": "Audio filter type to use."
                     }
                 }
-            }
+            },
+            "disableAllFiltersButton": "Disable all filters",
+            "allFiltersDisabled": "{{icon}} **Disabled filters**\nAll audio filters have been disabled.",
+            "selectFilterPlaceholder": "Select a filter from the menu.",
+            "selectFilterPlaceholderMany": "Select one or multiple filters.",
+            "toggleFilterInstructions": "**Toggle filters ({{provider}})**\nEnable or disable audio filters for playback from the menu."
         },
         "guilds": {
             "metadata": {

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -1,0 +1,21 @@
+{
+    "autocomplete": {
+        "trackName": "{{title}} [Author: {{author}}]"
+    },
+    "commands": {
+        "lyrics": {
+            "metadata": {
+                "description": "Search Genius lyrics for current or specified track. TEST",
+                "name": "lyrics",
+                "options": {
+                    "query": {
+                        "name": "query",
+                        "description": "Search query by text or URL. TEST"
+                    }
+                }
+            },
+            "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]"
+        },
+        "help": {}
+    }
+}

--- a/locales/i18next.d.ts
+++ b/locales/i18next.d.ts
@@ -1,0 +1,8 @@
+import Resources from './resources';
+
+declare module 'i18next' {
+    interface CustomTypeOptions {
+        defaultNS: 'bot';
+        resources: Resources;
+    }
+}

--- a/locales/no/bot.json
+++ b/locales/no/bot.json
@@ -325,6 +325,12 @@
             "volumeMuted": "{{icon}} **Lyd dempet**\nAvspillingslyden er dempet, fordi volumet ble satt til **`0%`**."
         }
     },
+    "components": {
+        "responses": {
+            "paused": "Pauset låt",
+            "resumed": "Gjenopptok låt"
+        }
+    },
     "musicPlayerCommon": {
         "controls": {
             "stop": "Stopp",
@@ -397,6 +403,7 @@
         "notValidGuildId": "{{icon}} **Oi sann!**\nIngen tillatelse til å utføre denne handlingen.\n\nKommandoen {{command}} kan ikke utføres på denne serveren.",
         "queueDoesNotExist": "{{icon}} **Oi sann!**\nDet er ingen låter i køen og ingenting spilles av for øyeblikket. Legg først til noen låter med {{playCommand}}!",
         "queueIsEmpty": "{{icon}} **Oi sann!\nDet er ingen låter lagt til i køen. Legg først til noen låter med {{playCommand}}!",
-        "queueNoCurrentTrack": "{{icon}} **Oi sann!**\nDet spilles ingenting av for øyeblikket. Legg først til noen låter med {{playCommand}}!"
+        "queueNoCurrentTrack": "{{icon}} **Oi sann!**\nDet spilles ingenting av for øyeblikket. Legg først til noen låter med {{playCommand}}!",
+        "trackNotPlayingAnymore": "{{icon}} **Oi sann!**\nDenne låten har blitt hoppet over allerede eller spiller ikke lenger."
     }
 }

--- a/locales/no/bot.json
+++ b/locales/no/bot.json
@@ -72,8 +72,8 @@
                 }
             },
             "emptyHistory": "Historikken er tom, legg til noen låter med {{playCommand}}!",
-            "invalidPageNumber_one": "{{icon}} **Oi sann!**\nSide **{{page}}** er ikke et gyldig sidenummer.\n\nDet er bare **`1`** side i historikken.",
-            "invalidPageNumber": "{{icon}} **Oi sann!**\nSide **{{page}}** er ikke et gyldig sidenummer.\n\nDet er totalt bare **`{{count}}`** sider i historikken.",
+            "invalidPageNumber_one": "{{icon}} **Oi sann!**\nSide **`{{page}}`** er ikke et gyldig sidenummer.\n\nDet er bare **`1`** side i historikken.",
+            "invalidPageNumber": "{{icon}} **Oi sann!**\nSide **`{{page}}`** er ikke et gyldig sidenummer.\n\nDet er totalt bare **`{{count}}`** sider i historikken.",
             "tracksInHistoryTitle": "{{icon}} **Låter i historikken**"
         },
         "join": {
@@ -203,7 +203,12 @@
                     }
                 }
             },
-            "tracksInQueueTitle": "{{icon}} **Låter i køen**"
+            "tracksInQueueTitle": "{{icon}} **Låter i køen**",
+            "emptyQueue": "Køen er tom, legg til noen låter med {{playCommand}}!",
+            "estimatedDuration": "Estimert tid igjen: {{duration}}",
+            "estimatedReallyLongTime": "Estimert tid igjen: Veldig lang tid",
+            "invalidPageNumber_one": "{{icon}} **Oi sann!**\nSide **`{{page}}`** er ikke et gyldig sidenummer.\n\nDet er bare **`1`** side i køen.",
+            "invalidPageNumber": "{{icon}} **Oi sann!**\nSide **`{{page}}`** er ikke et gyldig sidenummer.\n\nDet er totalt bare **`{{count}}`** sider i køen."
         },
         "reload": {
             "metadata": {

--- a/locales/no/bot.json
+++ b/locales/no/bot.json
@@ -1,0 +1,397 @@
+{
+    "autocomplete": {
+        "trackName": "{{title}} [Artist: {{author}}]"
+    },
+    "commands": {
+        "back": {
+            "metadata": {
+                "name": "back",
+                "description": "Gå tilbake til forrige låt eller angitt posisjon i historikken.",
+                "options": {
+                    "position": {
+                        "name": "posisjon",
+                        "description": "Posisjon for låt i historikken å gå tilbake til."
+                    }
+                }
+            },
+            "trackHistoryEmpty": "{{icon}} **Oi sann!**\nHistorikken er tom, legg til noen låter med {{playCommand}}!",
+            "trackPositionHigherThanHistoryLength_one": "{{icon}} **Oi sann!**\nDet er bare **1** låt i historikken. Du kan ikke gå tilbake til posisjon **{{backPosition}}**.\n\nVis låter lagt til i historikken med {{historyCommand}}.",
+            "trackPositionHigherThanHistoryLength": "{{icon}} **Oi sann!**\nDet er bare **{{count}}** låter i historikken. Du kan ikke gå tilbake til posisjon **{{backPosition}}**.\n\nVis låter lagt til i historikken med {{historyCommand}}.",
+            "trackRecovered": "{{icon}} **Gjenopprettet låt**\n{{track}}"
+        },
+        "filters": {
+            "metadata": {
+                "name": "filters",
+                "description": "Velg mellom ulike lydfiltre.",
+                "options": {
+                    "type": {
+                        "name": "type",
+                        "description": "Type lydfilter å bruke.",
+                        "choices": {
+                            "ffmpeg": "FFmpeg",
+                            "biquad": "Biquad",
+                            "equalizer": "Equalizer",
+                            "disable": "Deaktivert"
+                        }
+                    }
+                }
+            },
+            "allFiltersDisabled": "{{icon}} **Deaktiverte lydfiltre**\nAlle lydfiltre har blitt deaktivert.",
+            "disableAllFiltersButton": "Deaktiver alle lydfiltre",
+            "nowUsingFilters": "{{icon}} **Lydfiltre aktivert**\nBruker nå disse {{mode}} filtrene:",
+            "selectFilterPlaceholder": "Velg et lydfilter fra menyen.",
+            "selectFilterPlaceholderMany": "Velg ett eller flere lydfiltre.",
+            "toggleFilterInstructions": "**Juster filtre ({{provider}})**\nAktiver eller deaktiver lydfiltre fra menyen."
+        },
+        "guilds": {
+            "metadata": {
+                "name": "guilds",
+                "description": "Vis de 25 største serverne etter medlemstall."
+            },
+            "topGuildsByMemberCount": "{{icon}} **Topp {{count}} servere etter medlemstall ({{totalCount}} totalt)**",
+            "totalMembers": "**Totalt antall medlemmer:** **`{{count}`**"
+        },
+        "help": {
+            "metadata": {
+                "name": "help",
+                "description": "Vis listen over bot-kommandoer."
+            },
+            "addBotButton": "Legg til bot",
+            "listTitle": "{{icon}} **Liste over kommandoer**",
+            "supportServerButton": "Støtteserver"
+        },
+        "history": {
+            "metadata": {
+                "name": "history",
+                "description": "Vis historikk over låter som har blitt spilt.",
+                "options": {
+                    "page": {
+                        "name": "side",
+                        "description": "Sidenummer for å vise for historikken."
+                    }
+                }
+            },
+            "emptyHistory": "Historikken er tom, legg til noen låter med {{playCommand}}!",
+            "invalidPageNumber_one": "{{icon}} **Oi sann!**\nSide **{{page}}** er ikke et gyldig sidenummer.\n\nDet er bare **`1`** side i historikken.",
+            "invalidPageNumber": "{{icon}} **Oi sann!**\nSide **{{page}}** er ikke et gyldig sidenummer.\n\nDet er totalt bare **`{{count}}`** sider i historikken.",
+            "tracksInHistoryTitle": "{{icon}} **Låter i historikken**"
+        },
+        "join": {
+            "metadata": {
+                "name": "join",
+                "description": "Botten vil bli med i talekanalen hvis den ikke allerede er i en."
+            },
+            "alreadyConnected": "{{icon}} **Oi sann!**\nJeg er allerede koblet til talekanalen {{channel}}.\n\nFor å koble meg fra kanalen, bruk kommandoen {{leaveCommand}}.",
+            "couldNotJoin": "{{icon}} **Oi sann!**\nKunne ikke bli med i talekanalen, vennligst prøv igjen.",
+            "joinedChannel": "{{icon}} **Ble med i kanal**\nKoblet til talekanalen: {{channel}}\n\nFor å legge til låter, bruk kommandoen {{playCommand}}!"
+        },
+        "leave": {
+            "metadata": {
+                "name": "leave",
+                "description": "Tøm køen og fjern botten fra talekanalen."
+            },
+            "leavingChannel": "{{icon}} **Koblet fra kanal**\nTømte låtkøen og koblet fra talekanalen.\n\nFor å spille mer musikk, bruk kommandoen {{playCommand}}!"
+        },
+        "loop": {
+            "metadata": {
+                "name": "loop",
+                "description": "Velg mellom å spille en låt på reptisjon, hele køen eller autoplay.",
+                "options": {
+                    "mode": {
+                        "name": "modus",
+                        "description": "Loop-modus: Låt, kø, autoplay eller deaktivert.",
+                        "choices": {
+                            "0": "Deaktivert",
+                            "1": "Låt",
+                            "2": "Kø",
+                            "3": "Autoplay"
+                        }
+                    }
+                }
+            },
+            "alreadySet": "{{icon}} **Oi sann!**\nLoop-modus er allerede satt til **`{{mode}}`**.",
+            "loopModeInformation": "{{icon}} **Nåværende loop-modus**\nLoop-modusen er for øyeblikket satt til **`{{mode}}`**.",
+            "modeChanged": "{{icon}} **Endret loop-modus**\nEndrer loop-modus fra **`{{fromName}}`** til **`{{toName}}`**.",
+            "willAutoplay": "Når køen er tom, vil lignende låter begynne å spille!",
+            "willNoLongerPlay": "{{mode}} vil ikke lenger spille på repeat!",
+            "willNowPlay": "{{mode}} vil nå spille på repeat!"
+        },
+        "lyrics": {
+            "metadata": {
+                "name": "lyrics",
+                "description": "Søk etter Genius sangtekster for nåværende eller angitt låt.",
+                "options": {
+                    "query": {
+                        "name": "søk",
+                        "description": "Søkespørring etter tekst eller URL."
+                    }
+                }
+            },
+            "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]",
+            "lyricsEmbed": "{{icon}} **Viser sangtekster**\n**Låt: [{{trackTitle}}]({{trackUrl}})**\n**Artist: [{{artistName}}]({{artistUrl}})**",
+            "noLyricsFound": "{{icon}} **Ingen sangtekster funnet**\nDet ble ikke funnet noen Genius sangtekster for låten **{{query}}**."
+        },
+        "move": {
+            "metadata": {
+                "name": "move",
+                "description": "Flytt en låt til en spesifisert posisjon i køen.",
+                "options": {
+                    "from": {
+                        "name": "fra",
+                        "description": "Posisjonen til låten som skal flyttes."
+                    },
+                    "to": {
+                        "name": "til",
+                        "description": "Posisjonen for å flytte låten til."
+                    }
+                }
+            },
+            "trackMoved": "{{icon}} **Flyttet låten**\n{track}\n\nLåten har blitt flyttet fra posisjon **`{{fromPosition}}`** til posisjon **`{{toPosition}}`** i køen.",
+            "trackPositionHigherThanQueueLength_one": "{{icon}} **Oi sann!**\nDu kan ikke flytte låten i posisjon **`{{fromPosition}}`** til posisjon **`{{toPosition}}`** i køen. Det er bare **`1`** låt i køen.\n\nVis låter lagt til i køen med {{queueCommand}}.",
+            "trackPositionHigherThanQueueLength": "{{icon}} **Oi sann!**\nDu kan ikke flytte låten i posisjon **`{{fromPosition}}`** til posisjon **`{{toPosition}}`** i køen. Det er bare **`{{count}}`** låter i køen.\n\nVis låter lagt til i køen med {{queueCommand}}."
+        },
+        "nowplaying": {
+            "metadata": {
+                "name": "nowplaying",
+                "description": "Vis informasjon om nåværende låt."
+            },
+            "embedFields": {
+                "author": "**Artist**",
+                "plays": "**Avspillinger**",
+                "source": "**Kilde for låt**"
+            },
+            "otherTracksInQueue_one": "1 annen låt i køen...",
+            "otherTracksInQueue": "{{count}} andre låter i køen...",
+            "playCount_zero": "Ukjent",
+            "playCount": "{{count, number}}"
+        },
+        "pause": {
+            "metadata": {
+                "name": "pause",
+                "description": "Pause eller gjenoppta nåværende låt."
+            },
+            "pauseConfirmation": "{{icon}} **Pauset låten**",
+            "resumeConfirmation": "{{icon}} **Gjenopptok låten**",
+            "directSource": "Direkte kilde"
+        },
+        "play": {
+            "metadata": {
+                "name": "play",
+                "description": "Legg til en låt eller spilleliste i køen ved søkespørring eller URL.",
+                "options": {
+                    "query": {
+                        "name": "spørring",
+                        "description": "Søkespørring ved tekst eller URL."
+                    }
+                }
+            },
+            "addedToQueueTitle": "{{icon}} **Lagt til i køen**",
+            "playlistAddedTitle": "{{icon}} **Lagt til spilleliste i køen**",
+            "playlistAddedTrackCount_one": "Og **1** til låt... Bruk {{queueCommand}} for å se alle.",
+            "playlistAddedTrackCount": "Og **{{count}}** flere låter... Bruk {{queueCommand}} for å se alle.",
+            "playlistTooLarge": "{{icon}} **Spilleliste for stor**\nDenne spillelisten er for stor til å legges til i køen.\n\nMaksimalt antall låter som kan legges til i køen er **{{count}}**.",
+            "trackNotFound": "{{icon}} **Ingen låter funnet**\nIngen resultater funnet for **{{query}}**.\n\nHvis du angav en URL, vær sikker på at den er gyldig og offentlig."
+        },
+        "queue": {
+            "metadata": {
+                "name": "queue",
+                "description": "Vis låter som har blitt lagt til i køen.",
+                "options": {
+                    "page": {
+                        "name": "side",
+                        "description": "Sidenummer for å vise for køen."
+                    }
+                }
+            },
+            "tracksInQueueTitle": "{{icon}} **Låter i køen**"
+        },
+        "reload": {
+            "metadata": {
+                "name": "reload",
+                "description": "Last inn bot-kommandoer, autocompletion og component interaksjoner på nytt på tvers av shards."
+            },
+            "reloadedCommands": "{{icon}} **Kommandoer lastet inn på nytt**",
+            "unableToReload": "{{icon}} **Oi sann!**\n_Hmm..._ Det ser ut til at jeg ikke klarer å laste inn interaksjoner og kommandoer på tvers av shards."
+        },
+        "remove": {
+            "noTracksRemoved": "{{icon}} **Ingen låter fjernet**\nDet ble ikke fjernet noen låter fra køen. Vennligst sjekk om alternativet du valgte har låter som kan fjernes.",
+            "removedTrack": "{{icon}} **Fjernet låt**",
+            "removedTracks": "{{icon}} **Fjernet låter**\n**`{{count}}`** låter ble fjernet fra køen.",
+            "startPositionHigherThanEndPosition": "{{icon}} **Oi sann!**\nStartposisjon **`{{start}}`** er høyere enn siste posisjon **`{{end}}`** i køen. Vennligst spesifiser et gyldig område.\n\nVis låter lagt til i køen med {{queueCommand}}.",
+            "trackPositionHigherThanQueueLength_one": "{{icon}} **Oi sann!**\nPosisjon **`{{position}}`** er ikke en gyldig køposisjon. Det er bare **`1`** låt i køen.\n\nVis låter lagt til i køen med {{queueCommand}}.",
+            "trackPositionHigherThanQueueLength": "{{icon}} **Oi sann!**\nPosisjon **`{{position}}`** er ikke en gyldig køposisjon. Det er bare **`{{count}}`** låter i køen.\n\nVis låter lagt til i køen med {{queueCommand}}."
+        },
+        "seek": {
+            "metadata": {
+                "name": "seek",
+                "description": "Spol til tidsposisjon i nåværende låt.",
+                "options": {
+                    "duration": {
+                        "name": "varighet",
+                        "description": "Tidsstempel i format 00:00:00 (TT:mm:ss)."
+                    }
+                }
+            },
+            "correctFormatInstruction": "{{icon}} **Oi sann!**\nDu anga et ugyldig varighetsformat, **`{{wrongDuration}}`**.\nVennligst bruk formatet **`TT:mm:ss`**, **`mm:ss`** eller **`ss`**.\n\n**Eksempler:**\n- **`/seek`** **`1:24:12`** - Spol til 1 time, 24 minutter og 12 sekunder.\n- **`/seek`** **`3:27`** - Spol til 3 minutter og 27 sekunder.\n- **`/seek`** **`42`** - Spol til 42 sekunder.",
+            "durationLongerThanTrackDuration": "{{icon}} **Oi sann!**\nDu anga **`{{wrongDuration}}`**, som er et tidsstempel lengre enn varigheten av nåværende låt.\n\nVennligst prøv et tidsstempel som er mindre enn varigheten til låten (**{{trackDuration}}**).",
+            "seekingToTimestamp": "{{icon}} **Spoler til tidsposisjon**\nSpoler til **`{{duration}}`** i nåværende låt."
+        },
+        "shards": {
+            "metadata": {
+                "name": "shards",
+                "description": "Vis informasjon om alle tilkoblede shards.",
+                "options": {
+                    "sort": {
+                        "name": "sorter",
+                        "description": "Hva shards skal sorteres etter.",
+                        "choices": {
+                            "none": "Ingen (Shard ID)",
+                            "memory": "Minnebruk",
+                            "connections": "Taleforbindelser",
+                            "tracks": "Låter",
+                            "listeners": "Lyttere",
+                            "guilds": "Servere",
+                            "members": "Medlemmer"
+                        }
+                    },
+                    "page": {
+                        "name": "side",
+                        "description": "Sidenummer for å vise for shards."
+                    }
+                }
+            }
+        },
+        "shuffle": {
+            "metadata": {
+                "name": "shuffle",
+                "description": "Tilfeldig stokk om rekkefølgen til alle låter i køen."
+            },
+            "shuffledTracks": "{{icon}} **Stokket om rekkefølge**\n**{{count}}** låter i køen har blitt stokket om.\n\nVis den nye kørekkefølgen med {{queueCommand}}."
+        },
+        "skip": {
+            "metadata": {
+                "name": "skip",
+                "description": "Hopp over låt til neste eller angitt posisjon i køen.",
+                "options": {
+                    "position": {
+                        "name": "posisjon",
+                        "description": "Posisjon i køen for låt som skal hoppes til."
+                    }
+                }
+            },
+            "emptyQueue": "{{icon}} **Oi sann!**\nKøen er tom, legg til noen låter med {{playCommand}}!",
+            "skippedTrack": "{{icon}} **Hoppet over låt**",
+            "trackPositionHigherThanQueueLength_one": "{{icon}} **Oi sann!**\nDet er bare **1** låt i køen. Du kan ikke hoppe til posisijon **{{position}}** i køen.\n\nVis låter lagt til i køen med {{queueCommand}}.",
+            "trackPositionHigherThanQueueLength": "{{icon}} **Oi sann!**\nDet er bare **{{count}}** låter i køen. Du kan ikke hoppe til posisjon **{{position}}** i køen.\n\nVis låter lagt til i køen med {{queueCommand}}."
+        },
+        "status": {
+            "metadata": {
+                "name": "status",
+                "description": "Vis driftsstatus for botten."
+            }
+        },
+        "stop": {
+            "metadata": {
+                "name": "stop",
+                "description": "Tøm køen og slutt å spille lyd."
+            },
+            "stoppedPlaying": "{{icon}} **Stoppet å spille**\nStoppet å spille lyd og tømte køen.\n\nFor å spille mer musikk, bruk kommandoen {{playCommand}}!"
+        },
+        "systemstatus": {
+            "metadata": {
+                "name": "systemstatus",
+                "description": "Vis driftsstatus for botten med ytterligere teknisk informasjon."
+            }
+        },
+        "volume": {
+            "metadata": {
+                "name": "volume",
+                "description": "Vis eller endre avspillingsvolumet for låter.",
+                "options": {
+                    "percentage": {
+                        "name": "prosent",
+                        "description": "Volumprosent: Fra 1% til 100%."
+                    }
+                }
+            },
+            "invalidVolumeRange": "{{icon}} **Oi sann!**\nDu kan ikke sette volumet til **`{{wrongVolume}}%`**, vennligst velg en verdi mellom **`1%`** og **`100%`**.",
+            "volumeChanged": "{{icon}} **Volum endret**\nAvspillingsvolumet er endret til **`{{volume}}%`**.",
+            "volumeInformation": "{{icon}} **Avspillingsvolum**\nAvspillingsvolumet er for øyeblikket satt til **`{{volume}}`**.",
+            "volumeMuted": "{{icon}} **Lyd dempet**\nAvspillingslyden er dempet, fordi volumet ble satt til **`0%`**."
+        }
+    },
+    "musicPlayerCommon": {
+        "controls": {
+            "stop": "Stopp",
+            "previous": "Forrige",
+            "pause": "Pause",
+            "resume": "Gjenoppta",
+            "skip": "Hopp over"
+        },
+        "footerPageNumber_one": "Side {{page}} av {{pageCount}} (1 låt)",
+        "footerPageNumber": "Side {{page}} av {{pageCount}} ({{count}} låter)",
+        "loopingInfo": "{{icon}} **Looping aktivert**\nLoop-modus er satt til **`{{loopMode}}`**. Du kan endre det med {{loopCommand}}.\n",
+        "nowPausedTitle": "{{icon}} **For øyeblikket pauset**",
+        "nowPlayingTitle": "{{icon}} **Spiller nå**",
+        "playingLive": "{{icon}} **`DIREKTE`** - Spiller kontinuerlig fra direktekilde.",
+        "queueRepeatMode": {
+            "off": "Deaktivert",
+            "track": "Låt",
+            "queue": "Kø",
+            "autoplay": "Autoplay"
+        },
+        "requestedBy": "**Forespurt av:** {{user}}",
+        "unavailableAuthor": "Ikke tilgjengelig",
+        "unavailableDuration": "_Ingen varighet tilgjengelig._",
+        "unavailableRequestedBy": "Ikke tilgjengelig",
+        "unavailableTrackTitle": "Tittel ikke tilgjengelig",
+        "unavailableTrackUrl": "**Ikke tilgjengelig**",
+        "unavailableSource": "Ikke tilgjengelig",
+        "voiceChannelInfo": "Kanal: {{channel}} ({{bitrate}}kbps)"
+    },
+    "statistics": {
+        "botStatus": {
+            "title": "{{icon}} **Bot status**",
+            "joinedServers": "**{{count}}** Tilkoblede servere",
+            "joinedServers_one": "**1** Tilkoblet server",
+            "totalMembers": "**{{count}}** Totalt antall medlemmer",
+            "releaseVersion": "**{{version}}** Utgivelsesversjon"
+        },
+        "queueStatus": {
+            "title": "{{icon}} **Køstatus**",
+            "voiceConnections": "**{{count}}** Taleforbindelser",
+            "voiceConnections_one": "**1** Taleforbindelse",
+            "tracksInQueues": "**{{count}}** Låter i køer",
+            "tracksInQueues_one": "**1** Låt i køer",
+            "usersListening": "**{{count}}** Lyttere",
+            "usersListening_one": "**1** Lytter"
+        },
+        "systemStatus": {
+            "title": "{{icon}} **Systemstatus**",
+            "uptime": "**{{value}}** Oppetid",
+            "cpu": "**{{value, number(minimumFractionDigits: 2)}}%** CPU-bruk",
+            "cpuDetailed": "**{{usage}}% @ {{cores}} kjerner** CPU-bruk",
+            "memory": "**{{value, number}} MB** Minnebruk",
+            "memoryDetailed": "**{{used, number}} / {{total, number}} MB** Minnebruk",
+            "platform": "**{{value}}** Plattform"
+        },
+        "discordStatus": {
+            "title": "{{icon}} **Discord-status**",
+            "apiLatency": "**{{value, number}} ms** Discord API forsinkelse"
+        },
+        "dependencies": {
+            "title": "{{icon}} **Avhengigheter**"
+        }
+    },
+    "validation": {
+        "cannotJoinVoiceOrTalk": "{{icon}} **Oi sann!**\nJeg har ikke tillatelse til å spille lyd i talekanalen {{channel}}.\n\nVær sikker på at jeg har **`Koble til`** og **`Snakke`** tillatelsene i denne talekanalen.",
+        "cannotSendMessageInChannel": "{{icon}} **Oi sann!**\nJeg har ikke tillatelse til å sende meldingssvar i kanalen {{channel}}.\n\nVær sikker på at jeg har **`Se Kanal`** tillatelsen i denne tekstkanalen.",
+        "historyDoesNotExist": "{{icon}} **Oi sann!**\nDet er ingen låter i historikken og ingenting spilles av for øyeblikket. Legg først til noen låter med {{playCommand}}!",
+        "notInSameVoiceChannel": "{{icon}} **Ikke i samme talekanal**\nDu må være i samme talekanal som meg for å utføre denne handlingen.\n\n**Talekanal:** {{channel}}",
+        "notInVoiceChannel": "{{icon}} **Ikke i en talekanal**\nDu må være i en talekanal for å utføre denne handlingen.",
+        "notValidGuildId": "{{icon}} **Oi sann!**\nIngen tillatelse til å utføre denne handlingen.\n\nKommandoen {{command}} kan ikke utføres på denne serveren.",
+        "queueDoesNotExist": "{{icon}} **Oi sann!**\nDet er ingen låter i køen og ingenting spilles av for øyeblikket. Legg først til noen låter med {{playCommand}}!",
+        "queueIsEmpty": "{{icon}} **Oi sann!\nDet er ingen låter lagt til i køen. Legg først til noen låter med {{playCommand}}!",
+        "queueNoCurrentTrack": "{{icon}} **Oi sann!**\nDet spilles ingenting av for øyeblikket. Legg først til noen låter med {{playCommand}}!"
+    }
+}

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -27,7 +27,13 @@ interface Resources {
           "options": {
             "type": {
               "name": "type",
-              "description": "Audio filter type to use."
+              "description": "Audio filter type to use.",
+              "choices": {
+                "ffmpeg": "FFmpeg",
+                "biquad": "Biquad",
+                "equalizer": "Equalizer",
+                "disable": "Disable"
+              }
             }
           }
         },
@@ -94,7 +100,13 @@ interface Resources {
           "options": {
             "mode": {
               "name": "mode",
-              "description": "Loop mode: Track, queue, autoplay or disabled."
+              "description": "Loop mode: Track, queue, autoplay or disabled.",
+              "choices": {
+                "0": "Off",
+                "1": "Track",
+                "2": "Queue",
+                "3": "Autoplay"
+              }
             }
           }
         },
@@ -103,13 +115,7 @@ interface Resources {
         "modeChanged": "{{icon}} **Loop mode changed**\nChanging loop mode from **`{{fromName}}`** to **`{{toName}}`**.",
         "willAutoplay": "When the queue is empty, similar tracks will start playing!",
         "willNoLongerPlay": "The {{mode}} will no longer play on repeat!",
-        "willNowPlay": "The {{mode}} will now play on repeat!",
-        "repeatMode": {
-          "off": "disabled",
-          "track": "track",
-          "queue": "queue",
-          "autoplay": "autoplay"
-        }
+        "willNowPlay": "The {{mode}} will now play on repeat!"
       },
       "lyrics": {
         "metadata": {
@@ -149,7 +155,16 @@ interface Resources {
         "metadata": {
           "name": "nowplaying",
           "description": "Show information about the current track."
-        }
+        },
+        "embedFields": {
+          "author": "**Artist**",
+          "plays": "**Plays**",
+          "source": "**Track source**"
+        },
+        "otherTracksInQueue_one": "1 other track in the queue...",
+        "otherTracksInQueue": "{{count}} other tracks in the queue...",
+        "playCount_zero": "Unknown",
+        "playCount": "{{count, number}}"
       },
       "pause": {
         "metadata": {
@@ -157,7 +172,8 @@ interface Resources {
           "description": "Toggle pause for the current track."
         },
         "pauseConfirmation": "{{icon}} **Paused track**",
-        "resumeConfirmation": "{{icon}} **Resumed track**"
+        "resumeConfirmation": "{{icon}} **Resumed track**",
+        "directSource": "Direct source"
       },
       "play": {
         "metadata": {
@@ -228,7 +244,16 @@ interface Resources {
           "options": {
             "sort": {
               "name": "sort",
-              "description": "What to sort the shards by."
+              "description": "What to sort the shards by.",
+              "choices": {
+                "none": "None (Shard ID)",
+                "memory": "Memory usage",
+                "connections": "Voice Connections",
+                "tracks": "Tracks",
+                "listeners": "Listeners",
+                "guilds": "Guilds",
+                "members": "Members"
+              }
             },
             "page": {
               "name": "page",
@@ -307,13 +332,22 @@ interface Resources {
       "footerPageNumber_one": "Page {{page}} of {{pageCount}} (1 track)",
       "footerPageNumber": "Page {{page}} of {{pageCount}} ({{count}} tracks)",
       "loopingInfo": "{{icon}} **Looping**\nLoop mode is set to **`{{loopMode}}`**. You can change it with {{loopCommand}}.",
+      "nowPausedTitle": "{{icon}} **Currently paused**",
       "nowPlayingTitle": "{{icon}} **Now playing**",
       "playingLive": "{{icon}} **`LIVE`** - Playing continuously from live source.",
+      "queueRepeatMode": {
+        "off": "Disabled",
+        "track": "Track",
+        "queue": "Queue",
+        "autoplay": "Autoplay"
+      },
       "requestedBy": "**Requested by:** {{user}}",
+      "unavailableAuthor": "Unavailable",
       "unavailableDuration": "_No duration available._",
       "unavailableRequestedBy": "Unavailable",
       "unavailableTrackTitle": "Title unavailable",
       "unavailableTrackUrl": "**Unavailable**",
+      "unavailableSource": "Unavailable",
       "voiceChannelInfo": "Channel: {{channel}} ({{bitrate}}kbps)"
     },
     "statistics": {

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -15,9 +15,9 @@ interface Resources {
             }
           }
         },
-        "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
-        "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
         "trackHistoryEmpty": "{{icon}} **Oops!**\nThe history is empty, add some tracks with {{playCommand}}!",
+        "trackPositionHigherThanHistoryLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
+        "trackPositionHigherThanHistoryLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
         "trackRecovered": "{{icon}} **Recovered track**\n{{track}}"
       },
       "filters": {
@@ -31,8 +31,9 @@ interface Resources {
             }
           }
         },
-        "disableAllFiltersButton": "Disable all filters",
         "allFiltersDisabled": "{{icon}} **Disabled filters**\nAll audio filters have been disabled.",
+        "disableAllFiltersButton": "Disable all filters",
+        "nowUsingFilters": "{{icon}} **Filters toggled**\nNow using these {{mode}} filters:",
         "selectFilterPlaceholder": "Select a filter from the menu.",
         "selectFilterPlaceholderMany": "Select one or multiple filters.",
         "toggleFilterInstructions": "**Toggle filters ({{provider}})**\nEnable or disable audio filters for playback from the menu."
@@ -41,16 +42,18 @@ interface Resources {
         "metadata": {
           "name": "guilds",
           "description": "Show the top 25 guilds by member count."
-        }
+        },
+        "topGuildsByMemberCount": "{{icon}} **Top {{count}} guilds by member count ({{totalCount}} total)**",
+        "totalMembers": "**Total members:** **`{{count}`**"
       },
       "help": {
         "metadata": {
           "name": "help",
           "description": "Show the list of bot commands."
         },
+        "addBotCallout": "{{icon}} **Enjoying {{botName}}?**\nAdd me to another server:\n**[Click me!]({{invite}})**",
         "listTitle": "{{icon}} **List of commands**",
-        "supportServerCallout": "{{icon}} **Support server**\nJoin the support server for help or to suggest improvements:\n{{invite}}",
-        "addBotCallout": "{{icon}} **Enjoying {{botName}}?**\nAdd me to another server:\n**[Click me!]({{invite}})**"
+        "supportServerCallout": "{{icon}} **Support server**\nJoin the support server for help or to suggest improvements:\n{{invite}}"
       },
       "history": {
         "metadata": {
@@ -62,19 +65,27 @@ interface Resources {
               "description": "Page number to display for the history."
             }
           }
-        }
+        },
+        "emptyHistory": "The history is empty, add some tracks with {{playCommand}}!",
+        "invalidPageNumber_one": "{{icon}} **Oops!**\nPage **{{page}}** is not a valid page number.\n\nThere is only **`1`** page in the history.",
+        "invalidPageNumber": "{{icon}} **Oops!**\nPage **{{page}}** is not a valid page number.\n\nThere are only a total of **`{{count}}`** pages in the history.",
+        "tracksInHistoryTitle": "{{icon}} **Tracks in history**"
       },
       "join": {
         "metadata": {
           "name": "join",
           "description": "The bot will join the voice channel if not already in one."
-        }
+        },
+        "alreadyConnected": "{{icon}} **Oops!**\nI am already connected to the {{channel}} voice channel.\n\nTo disconnect me from the channel, use the {{leaveCommand}} command.",
+        "couldNotJoin": "{{icon}} **Oops!**\nCould not join voice channel, please try again.",
+        "joinedChannel": "{{icon}} **Joined channel**\nConnected to voice channel: {{channel}}\n\nTo add tracks, use the {{playCommand}} command!"
       },
       "leave": {
         "metadata": {
           "name": "leave",
           "description": "Clear the queue and remove bot from voice channel."
-        }
+        },
+        "leavingChannel": "{{icon}} **Leaving channel**\nCleared the track queue and left voice channel.\n\nTo play more music, use the {{playCommand}} command!"
       },
       "loop": {
         "metadata": {
@@ -86,6 +97,18 @@ interface Resources {
               "description": "Loop mode: Track, queue, autoplay or disabled."
             }
           }
+        },
+        "alreadySet": "{{icon}} **Oops!**\nLoop mode is already **`{{mode}}`**.",
+        "loopModeInformation": "{{icon}} **Current loop mode**\nThe looping mode is currently set to **`{{mode}}`**.",
+        "modeChanged": "{{icon}} **Loop mode changed**\nChanging loop mode from **`{{fromName}}`** to **`{{toName}}`**.",
+        "willAutoplay": "When the queue is empty, similar tracks will start playing!",
+        "willNoLongerPlay": "The {{mode}} will no longer play on repeat!",
+        "willNowPlay": "The {{mode}} will now play on repeat!",
+        "repeatMode": {
+          "off": "disabled",
+          "track": "track",
+          "queue": "queue",
+          "autoplay": "autoplay"
         }
       },
       "lyrics": {
@@ -99,7 +122,9 @@ interface Resources {
             }
           }
         },
-        "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]"
+        "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]",
+        "lyricsEmbed": "{{icon}} **Showing lyrics**\n**Track: [{{trackTitle}}]({{trackUrl}})**\n**Artist: [{{artistName}}]({{artistUrl}})**",
+        "noLyricsFound": "{{icon}} **No lyrics found**\nThere were no Genius lyrics found for track **{{query}}**."
       },
       "move": {
         "metadata": {
@@ -115,7 +140,10 @@ interface Resources {
               "description": "The position to move the track to."
             }
           }
-        }
+        },
+        "trackMoved": "{{icon}} **Moved track**\n{track}\n\nTrack has been moved from position **`{{fromPosition}}`** to position **`{{toPosition}}`**.",
+        "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nYou cannot move the track in position **`{{fromPosition}}`** to position **`{{toPosition}}`**. There is only **`1`** track in the queue.\n\nView tracks added to the queue with {{queueCommand}}.",
+        "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nYou cannot move the track in position **`{{fromPosition}}`** to position **`{{toPosition}}`**. There are only **`{{count}}`** tracks in the queue.\n\nView tracks added to the queue with {{queueCommand}}."
       },
       "nowplaying": {
         "metadata": {
@@ -127,7 +155,9 @@ interface Resources {
         "metadata": {
           "name": "pause",
           "description": "Toggle pause for the current track."
-        }
+        },
+        "pauseConfirmation": "{{icon}} **Paused track**",
+        "resumeConfirmation": "{{icon}} **Resumed track**"
       },
       "play": {
         "metadata": {
@@ -139,7 +169,13 @@ interface Resources {
               "description": "Search query by text or URL."
             }
           }
-        }
+        },
+        "addedToQueueTitle": "{{icon}} **Added to queue**",
+        "playlistAddedTitle": "{{icon}} **Added playlist to queue**",
+        "playlistAddedTrackCount_one": "And **1** more track... Use {{queueCommand}} to view all.",
+        "playlistAddedTrackCount": "And **{{count}}** more tracks... Use {{queueCommand}} to view all.",
+        "playlistTooLarge": "{{icon}} **Playlist too large**\nThis playlist is too large to be added to the queue.\n\nThe maximum amount of tracks that can be added to the queue is **{{count}}**.",
+        "trackNotFound": "{{icon}} **No track found\nNo results found for **{{query}}**.\n\nIf you specified a URL, please make sure it is valid and public."
       },
       "queue": {
         "metadata": {
@@ -151,13 +187,24 @@ interface Resources {
               "description": "Page number to display for the queue."
             }
           }
-        }
+        },
+        "tracksInQueueTitle": "{{icon}} **Tracks in queue**"
       },
       "reload": {
         "metadata": {
           "name": "reload",
           "description": "Reload slash command, autocomplete and component interactions across shards."
-        }
+        },
+        "reloadedCommands": "{{icon}} **Reloaded commands**",
+        "unableToReload": "{{icon}} **Oops!**\n_Hmm..._ It seems I am unable to reload the interaction module across shards."
+      },
+      "remove": {
+        "noTracksRemoved": "{{icon}} **No tracks removed**\nThere were no tracks removed from the queue. Please check if the option you selected has tracks to remove.",
+        "removedTrack": "{{icon}} **Removed track**",
+        "removedTracks": "{{icon}} **Removed tracks**\n**`{{count}}`** tracks were removed from the queue.",
+        "startPositionHigherThanEndPosition": "{{icon}} **Oops!**\nStart position **`{{start}}`** is higher than end position **`{{end}}`**. Please specify a valid range.\n\nView tracks added to the queue with {{queueCommand}}.",
+        "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nPosition **`{{position}}`** is not a valid track position. There is only a total of **`1`** track in the queue.\n\nView the tracks added to the queue with {{queueCommand}}.",
+        "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nPosition **`{{position}}`** is not a valid track position. There are only a total of **`{{count}}`** tracks in the queue.\n\nView the tracks added to the queue with {{queueCommand}}."
       },
       "seek": {
         "metadata": {
@@ -166,10 +213,13 @@ interface Resources {
           "options": {
             "duration": {
               "name": "duration",
-              "description": "Duration in format 00:00:00 (HH:mm:ss)."
+              "description": "Timestamp in format 00:00:00 (HH:mm:ss)."
             }
           }
-        }
+        },
+        "correctFormatInstruction": "{{icon}} **Oops!**\nYou entered an invalid duration format, **`{{wrongDuration}}`**.\nPlease use the format **`HH:mm:ss`**, **`mm:ss`** or **`ss`**.\n\n**Examples:**\n- **`/seek`** **`1:24:12`** - Seek to 1 hour, 24 minutes and 12 seconds.\n- **`/seek`** **`3:27`** - Seek to 3 minutes and 27 seconds.\n- **`/seek`** **`42`** - Seek to 42 seconds.",
+        "durationLongerThanTrackDuration": "{{icon}} **Oops!**\nYou entered **`{{wrongDuration}}`**, which is a timestamp longer than the duration of the current track.\n\nPlease try a timestamp that is less than the duration of the track (**{{trackDuration}}**).",
+        "seekingToTimestamp": "{{icon}} **Seeking to timestamp**\nSeeking to **`{{duration}}`** in current track."
       },
       "shards": {
         "metadata": {
@@ -191,7 +241,8 @@ interface Resources {
         "metadata": {
           "name": "shuffle",
           "description": "Randomly shuffle all tracks in the queue."
-        }
+        },
+        "shuffledTracks": "{{icon}} **Shuffled queue tracks**\nThe **{{count}}** tracks in the queue have been shuffled.\n\nView the new queue order with {{queueCommand}}."
       },
       "skip": {
         "metadata": {
@@ -203,7 +254,11 @@ interface Resources {
               "description": "The position in queue to skip to."
             }
           }
-        }
+        },
+        "emptyQueue": "{{icon}} **Oops!**\nThe queue is empty, add some tracks with {{playCommand}}!",
+        "skippedTrack": "{{icon}} **Skipped track**",
+        "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the queue. You cannot skip to track **{{position}}**.\n\nView tracks added to the queue with {{queueCommand}}.",
+        "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the queue. You cannot skip to track **{{position}}**.\n\nView tracks added to the queue with {{queueCommand}}."
       },
       "status": {
         "metadata": {
@@ -215,7 +270,8 @@ interface Resources {
         "metadata": {
           "name": "stop",
           "description": "Clear the queue and stop playing audio."
-        }
+        },
+        "stoppedPlaying": "{{icon}} **Stopped playing**\nStopped playing the audio and cleared the track queue.\n\nTo play more music, use the {{playCommand}} command!"
       },
       "systemstatus": {
         "metadata": {
@@ -233,8 +289,32 @@ interface Resources {
               "description": "Volume percentage: From 1% to 100%."
             }
           }
-        }
+        },
+        "invalidVolumeRange": "{{icon}} **Oops!**\nYou cannot set the volume to **`{{wrongVolume}}%`**, please pick a value between **`1%`** and **`100%`**.",
+        "volumeChanged": "{{icon}} **Volume changed**\nPlayback volume has been changed to **`{{volume}}%`**.",
+        "volumeInformation": "{{icon}} **Playback volume**\nThe playback volume is currently set to **`{{volume}}`**.",
+        "volumeMuted": "{{icon}} **Audio muted**\nPlayback audio has been muted, because the volume was set to **`0%`**."
       }
+    },
+    "musicPlayerCommon": {
+      "controls": {
+        "stop": "Stop",
+        "previous": "Previous",
+        "pause": "Pause",
+        "resume": "Resume",
+        "skip": "Skip"
+      },
+      "footerPageNumber_one": "Page {{page}} of {{pageCount}} (1 track)",
+      "footerPageNumber": "Page {{page}} of {{pageCount}} ({{count}} tracks)",
+      "loopingInfo": "{{icon}} **Looping**\nLoop mode is set to **`{{loopMode}}`**. You can change it with {{loopCommand}}.",
+      "nowPlayingTitle": "{{icon}} **Now playing**",
+      "playingLive": "{{icon}} **`LIVE`** - Playing continuously from live source.",
+      "requestedBy": "**Requested by:** {{user}}",
+      "unavailableDuration": "_No duration available._",
+      "unavailableRequestedBy": "Unavailable",
+      "unavailableTrackTitle": "Title unavailable",
+      "unavailableTrackUrl": "**Unavailable**",
+      "voiceChannelInfo": "Channel: {{channel}} ({{bitrate}}kbps)"
     },
     "statistics": {
       "botStatus": {
@@ -269,6 +349,17 @@ interface Resources {
       "dependencies": {
         "title": "{{icon}} **Dependencies**"
       }
+    },
+    "validation": {
+      "cannotJoinVoiceOrTalk": "{{icon}} **Oops!**\nI do not have permission to play audio in the voice channel {{channel}}.\n\nPlease make sure I have the **`Connect`** and **`Speak`** permissions in this voice channel.",
+      "cannotSendMessageInChannel": "{{icon}} **Oops!**\nI do not have permission to send message replies in the channel {{channel}}.\n\nPlease make sure I have the **`View Channel`** permission in this text channel.",
+      "historyDoesNotExist": "{{icon}} **Oops!**\nThere are no tracks in the history and nothing currently playing. First add some tracks with {{playCommand}}!",
+      "notInSameVoiceChannel": "{{icon}} **Not in same voice channel**\nYou need to be in the same voice channel as me to perform this action.\n\n**Voice channel:** {{channel}}",
+      "notInVoiceChannel": "{{icon}} **Not in a voice channel**\nYou need to be in a voice channel to perform this action.",
+      "notValidGuildId": "{{icon}} **Oops!**\nNo permission to perform this action.\n\nThe command {{command}} cannot be executed in this server.",
+      "queueDoesNotExist": "{{icon}} **Oops!**\nThere are no tracks in the queue and nothing currently playing. First add some tracks with {{playCommand}}!",
+      "queueIsEmpty": "{{icon}} **Oops!\nThere are no tracks added to the queue. First add some tracks with {{playCommand}}!",
+      "queueNoCurrentTrack": "{{icon}} **Oops!**\nThere is nothing currently playing. First add some tracks with {{playCommand}}!"
     }
   }
 }

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -30,7 +30,12 @@ interface Resources {
               "description": "Audio filter type to use."
             }
           }
-        }
+        },
+        "disableAllFiltersButton": "Disable all filters",
+        "allFiltersDisabled": "{{icon}} **Disabled filters**\nAll audio filters have been disabled.",
+        "selectFilterPlaceholder": "Select a filter from the menu.",
+        "selectFilterPlaceholderMany": "Select one or multiple filters.",
+        "toggleFilterInstructions": "**Toggle filters ({{provider}})**\nEnable or disable audio filters for playback from the menu."
       },
       "guilds": {
         "metadata": {

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -4,20 +4,228 @@ interface Resources {
       "trackName": "{{title}} [Author: {{author}}]"
     },
     "commands": {
+      "back": {
+        "metadata": {
+          "name": "back",
+          "description": "Go back to previous track or specified position in history.",
+          "options": {
+            "position": {
+              "name": "position",
+              "description": "The position in history to go back to."
+            }
+          }
+        }
+      },
+      "filters": {
+        "metadata": {
+          "name": "filters",
+          "description": "Toggle various audio filters.",
+          "options": {
+            "type": {
+              "name": "type",
+              "description": "Audio filter type to use."
+            }
+          }
+        }
+      },
+      "guilds": {
+        "metadata": {
+          "name": "guilds",
+          "description": "Show the top 25 guilds by member count."
+        }
+      },
+      "help": {
+        "metadata": {
+          "name": "help",
+          "description": "Show the list of bot commands."
+        },
+        "listTitle": "{{icon}} **List of commands**",
+        "supportServerCallout": "{{icon}} **Support server**\nJoin the support server for help or to suggest improvements:\n{{invite}}",
+        "addBotCallout": "{{icon}} **Enjoying {{botName}}?**\nAdd me to another server:\n**[Click me!]({{invite}})**"
+      },
+      "history": {
+        "metadata": {
+          "name": "history",
+          "description": "Show history of tracks that have been played.",
+          "options": {
+            "page": {
+              "name": "page",
+              "description": "Page number to display for the history."
+            }
+          }
+        }
+      },
+      "join": {
+        "metadata": {
+          "name": "join",
+          "description": "The bot will join the voice channel if not already in one."
+        }
+      },
+      "leave": {
+        "metadata": {
+          "name": "leave",
+          "description": "Clear the queue and remove bot from voice channel."
+        }
+      },
+      "loop": {
+        "metadata": {
+          "name": "loop",
+          "description": "Toggle looping a track, the whole queue or autoplay.",
+          "options": {
+            "mode": {
+              "name": "mode",
+              "description": "Loop mode: Track, queue, autoplay or disabled."
+            }
+          }
+        }
+      },
       "lyrics": {
         "metadata": {
-          "description": "Search Genius lyrics for current or specified track. TEST",
           "name": "lyrics",
+          "description": "Search Genius lyrics for current or specified track.",
           "options": {
             "query": {
               "name": "query",
-              "description": "Search query by text or URL. TEST"
+              "description": "Search query by text or URL."
             }
           }
         },
         "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]"
       },
-      "help": {}
+      "move": {
+        "metadata": {
+          "name": "move",
+          "description": "Move a track to a specified position in queue.",
+          "options": {
+            "from": {
+              "name": "from",
+              "description": "The position of the track to move."
+            },
+            "to": {
+              "name": "to",
+              "description": "The position to move the track to."
+            }
+          }
+        }
+      },
+      "nowplaying": {
+        "metadata": {
+          "name": "nowplaying",
+          "description": "Show information about the current track."
+        }
+      },
+      "pause": {
+        "metadata": {
+          "name": "pause",
+          "description": "Toggle pause for the current track."
+        }
+      },
+      "play": {
+        "metadata": {
+          "name": "play",
+          "description": "Add a track or playlist to the queue by search query or URL.",
+          "options": {
+            "query": {
+              "name": "query",
+              "description": "Search query by text or URL."
+            }
+          }
+        }
+      },
+      "queue": {
+        "metadata": {
+          "name": "queue",
+          "description": "Show tracks that have been added to the queue.",
+          "options": {
+            "page": {
+              "name": "page",
+              "description": "Page number to display for the queue."
+            }
+          }
+        }
+      },
+      "reload": {
+        "metadata": {
+          "name": "reload",
+          "description": "Reload slash command, autocomplete and component interactions across shards."
+        }
+      },
+      "seek": {
+        "metadata": {
+          "name": "seek",
+          "description": "Seek to a position in the current track.",
+          "options": {
+            "duration": {
+              "name": "duration",
+              "description": "Duration in format 00:00:00 (HH:mm:ss)."
+            }
+          }
+        }
+      },
+      "shards": {
+        "metadata": {
+          "name": "shards",
+          "description": "Show information about all connected shards.",
+          "options": {
+            "sort": {
+              "name": "sort",
+              "description": "What to sort the shards by."
+            },
+            "page": {
+              "name": "page",
+              "description": "Page number to display for the shards."
+            }
+          }
+        }
+      },
+      "shuffle": {
+        "metadata": {
+          "name": "shuffle",
+          "description": "Randomly shuffle all tracks in the queue."
+        }
+      },
+      "skip": {
+        "metadata": {
+          "name": "skip",
+          "description": "Skip track to next or specified position in queue.",
+          "options": {
+            "position": {
+              "name": "position",
+              "description": "The position in queue to skip to."
+            }
+          }
+        }
+      },
+      "status": {
+        "metadata": {
+          "name": "status",
+          "description": "Show operational status of the bot."
+        }
+      },
+      "stop": {
+        "metadata": {
+          "name": "stop",
+          "description": "Clear the queue and stop playing audio."
+        }
+      },
+      "systemstatus": {
+        "metadata": {
+          "name": "systemstatus",
+          "description": "Show operational status of the bot with additional technical information."
+        }
+      },
+      "volume": {
+        "metadata": {
+          "name": "volume",
+          "description": "Show or change the playback volume for tracks.",
+          "options": {
+            "percentage": {
+              "name": "percentage",
+              "description": "Volume percentage: From 1% to 100%."
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -226,6 +226,40 @@ interface Resources {
           }
         }
       }
+    },
+    "statistics": {
+      "botStatus": {
+        "title": "{{icon}} **Bot status**",
+        "joinedServers": "**{{count}}** Joined servers",
+        "joinedServers_one": "**1** Joined server",
+        "totalMembers": "**{{count}}** Total members",
+        "releaseVersion": "**{{version}}** Release version"
+      },
+      "queueStatus": {
+        "title": "{{icon}} **Queue status**",
+        "voiceConnections": "**{{count}}** Voice connections",
+        "voiceConnections_one": "**1** Voice connection",
+        "tracksInQueues": "**{{count}}** Tracks in queues",
+        "tracksInQueues_one": "**1** Track in queues",
+        "usersListening": "**{{count}}** Users listening",
+        "usersListening_one": "**1** User listening"
+      },
+      "systemStatus": {
+        "title": "{{icon}} **System status**",
+        "uptime": "**{{value}}** Uptime",
+        "cpu": "**{{value, number(minimumFractionDigits: 2)}}%** CPU usage",
+        "cpuDetailed": "**{{usage}}% @ {{cores}} cores** CPU usage",
+        "memory": "**{{value, number}} MB** Memory usage",
+        "memoryDetailed": "**{{used, number}} / {{total, number}} MB** Memory usage",
+        "platform": "**{{value}}** Platform"
+      },
+      "discordStatus": {
+        "title": "{{icon}} **Discord status**",
+        "apiLatency": "**{{value, number}} ms** Discord API latency"
+      },
+      "dependencies": {
+        "title": "{{icon}} **Dependencies**"
+      }
     }
   }
 }

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -1,0 +1,25 @@
+interface Resources {
+  "bot": {
+    "autocomplete": {
+      "trackName": "{{title}} [Author: {{author}}]"
+    },
+    "commands": {
+      "lyrics": {
+        "metadata": {
+          "description": "Search Genius lyrics for current or specified track. TEST",
+          "name": "lyrics",
+          "options": {
+            "query": {
+              "name": "query",
+              "description": "Search query by text or URL. TEST"
+            }
+          }
+        },
+        "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]"
+      },
+      "help": {}
+    }
+  }
+}
+
+export default Resources;

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -14,7 +14,11 @@ interface Resources {
               "description": "The position in history to go back to."
             }
           }
-        }
+        },
+        "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
+        "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
+        "trackHistoryEmpty": "{{icon}} **Oops!**\nThe history is empty, add some tracks with {{playCommand}}!",
+        "trackRecovered": "{{icon}} **Recovered track**\n{{track}}"
       },
       "filters": {
         "metadata": {

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -1,401 +1,406 @@
 interface Resources {
-  "bot": {
-    "autocomplete": {
-      "trackName": "{{title}} [Author: {{author}}]"
-    },
-    "commands": {
-      "back": {
-        "metadata": {
-          "name": "back",
-          "description": "Go back to previous track or specified position in history.",
-          "options": {
-            "position": {
-              "name": "position",
-              "description": "The position in history to go back to."
-            }
-          }
-        },
-        "trackHistoryEmpty": "{{icon}} **Oops!**\nThe history is empty, add some tracks with {{playCommand}}!",
-        "trackPositionHigherThanHistoryLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
-        "trackPositionHigherThanHistoryLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.",
-        "trackRecovered": "{{icon}} **Recovered track**\n{{track}}"
-      },
-      "filters": {
-        "metadata": {
-          "name": "filters",
-          "description": "Toggle various audio filters.",
-          "options": {
-            "type": {
-              "name": "type",
-              "description": "Audio filter type to use.",
-              "choices": {
-                "ffmpeg": "FFmpeg",
-                "biquad": "Biquad",
-                "equalizer": "Equalizer",
-                "disable": "Disable"
-              }
-            }
-          }
-        },
-        "allFiltersDisabled": "{{icon}} **Disabled filters**\nAll audio filters have been disabled.",
-        "disableAllFiltersButton": "Disable all filters",
-        "nowUsingFilters": "{{icon}} **Filters toggled**\nNow using these {{mode}} filters:",
-        "selectFilterPlaceholder": "Select a filter from the menu.",
-        "selectFilterPlaceholderMany": "Select one or multiple filters.",
-        "toggleFilterInstructions": "**Toggle filters ({{provider}})**\nEnable or disable audio filters for playback from the menu."
-      },
-      "guilds": {
-        "metadata": {
-          "name": "guilds",
-          "description": "Show the top 25 guilds by member count."
-        },
-        "topGuildsByMemberCount": "{{icon}} **Top {{count}} guilds by member count ({{totalCount}} total)**",
-        "totalMembers": "**Total members:** **`{{count}`**"
-      },
-      "help": {
-        "metadata": {
-          "name": "help",
-          "description": "Show the list of bot commands."
-        },
-        "addBotButton": "Add bot",
-        "listTitle": "{{icon}} **List of commands**",
-        "supportServerButton": "Support server"
-      },
-      "history": {
-        "metadata": {
-          "name": "history",
-          "description": "Show history of tracks that have been played.",
-          "options": {
-            "page": {
-              "name": "page",
-              "description": "Page number to display for the history."
-            }
-          }
-        },
-        "emptyHistory": "The history is empty, add some tracks with {{playCommand}}!",
-        "invalidPageNumber_one": "{{icon}} **Oops!**\nPage **{{page}}** is not a valid page number.\n\nThere is only **`1`** page in the history.",
-        "invalidPageNumber": "{{icon}} **Oops!**\nPage **{{page}}** is not a valid page number.\n\nThere are only a total of **`{{count}}`** pages in the history.",
-        "tracksInHistoryTitle": "{{icon}} **Tracks in history**"
-      },
-      "join": {
-        "metadata": {
-          "name": "join",
-          "description": "The bot will join the voice channel if not already in one."
-        },
-        "alreadyConnected": "{{icon}} **Oops!**\nI am already connected to the {{channel}} voice channel.\n\nTo disconnect me from the channel, use the {{leaveCommand}} command.",
-        "couldNotJoin": "{{icon}} **Oops!**\nCould not join voice channel, please try again.",
-        "joinedChannel": "{{icon}} **Joined channel**\nConnected to voice channel: {{channel}}\n\nTo add tracks, use the {{playCommand}} command!"
-      },
-      "leave": {
-        "metadata": {
-          "name": "leave",
-          "description": "Clear the queue and remove bot from voice channel."
-        },
-        "leavingChannel": "{{icon}} **Leaving channel**\nCleared the track queue and left voice channel.\n\nTo play more music, use the {{playCommand}} command!"
-      },
-      "loop": {
-        "metadata": {
-          "name": "loop",
-          "description": "Toggle looping a track, the whole queue or autoplay.",
-          "options": {
-            "mode": {
-              "name": "mode",
-              "description": "Loop mode: Track, queue, autoplay or disabled.",
-              "choices": {
-                "0": "Off",
-                "1": "Track",
-                "2": "Queue",
-                "3": "Autoplay"
-              }
-            }
-          }
-        },
-        "alreadySet": "{{icon}} **Oops!**\nLoop mode is already **`{{mode}}`**.",
-        "loopModeInformation": "{{icon}} **Current loop mode**\nThe looping mode is currently set to **`{{mode}}`**.",
-        "modeChanged": "{{icon}} **Loop mode changed**\nChanging loop mode from **`{{fromName}}`** to **`{{toName}}`**.",
-        "willAutoplay": "When the queue is empty, similar tracks will start playing!",
-        "willNoLongerPlay": "The {{mode}} will no longer play on repeat!",
-        "willNowPlay": "The {{mode}} will now play on repeat!"
-      },
-      "lyrics": {
-        "metadata": {
-          "name": "lyrics",
-          "description": "Search Genius lyrics for current or specified track.",
-          "options": {
-            "query": {
-              "name": "query",
-              "description": "Search query by text or URL."
-            }
-          }
-        },
-        "autocompleteSearchResult": "{{title}} [Artist: {{artist}}]",
-        "lyricsEmbed": "{{icon}} **Showing lyrics**\n**Track: [{{trackTitle}}]({{trackUrl}})**\n**Artist: [{{artistName}}]({{artistUrl}})**",
-        "noLyricsFound": "{{icon}} **No lyrics found**\nThere were no Genius lyrics found for track **{{query}}**."
-      },
-      "move": {
-        "metadata": {
-          "name": "move",
-          "description": "Move a track to a specified position in queue.",
-          "options": {
-            "from": {
-              "name": "from",
-              "description": "The position of the track to move."
-            },
-            "to": {
-              "name": "to",
-              "description": "The position to move the track to."
-            }
-          }
-        },
-        "trackMoved": "{{icon}} **Moved track**\n{track}\n\nTrack has been moved from position **`{{fromPosition}}`** to position **`{{toPosition}}`**.",
-        "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nYou cannot move the track in position **`{{fromPosition}}`** to position **`{{toPosition}}`**. There is only **`1`** track in the queue.\n\nView tracks added to the queue with {{queueCommand}}.",
-        "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nYou cannot move the track in position **`{{fromPosition}}`** to position **`{{toPosition}}`**. There are only **`{{count}}`** tracks in the queue.\n\nView tracks added to the queue with {{queueCommand}}."
-      },
-      "nowplaying": {
-        "metadata": {
-          "name": "nowplaying",
-          "description": "Show information about the current track."
-        },
-        "embedFields": {
-          "author": "**Artist**",
-          "plays": "**Plays**",
-          "source": "**Track source**"
-        },
-        "otherTracksInQueue_one": "1 other track in the queue...",
-        "otherTracksInQueue": "{{count}} other tracks in the queue...",
-        "playCount_zero": "Unknown",
-        "playCount": "{{count, number}}"
-      },
-      "pause": {
-        "metadata": {
-          "name": "pause",
-          "description": "Toggle pause for the current track."
-        },
-        "pauseConfirmation": "{{icon}} **Paused track**",
-        "resumeConfirmation": "{{icon}} **Resumed track**",
-        "directSource": "Direct source"
-      },
-      "play": {
-        "metadata": {
-          "name": "play",
-          "description": "Add a track or playlist to the queue by search query or URL.",
-          "options": {
-            "query": {
-              "name": "query",
-              "description": "Search query by text or URL."
-            }
-          }
-        },
-        "addedToQueueTitle": "{{icon}} **Added to queue**",
-        "playlistAddedTitle": "{{icon}} **Added playlist to queue**",
-        "playlistAddedTrackCount_one": "And **1** more track... Use {{queueCommand}} to view all.",
-        "playlistAddedTrackCount": "And **{{count}}** more tracks... Use {{queueCommand}} to view all.",
-        "playlistTooLarge": "{{icon}} **Playlist too large**\nThis playlist is too large to be added to the queue.\n\nThe maximum amount of tracks that can be added to the queue is **{{count}}**.",
-        "trackNotFound": "{{icon}} **No track found\nNo results found for **{{query}}**.\n\nIf you specified a URL, please make sure it is valid and public."
-      },
-      "queue": {
-        "metadata": {
-          "name": "queue",
-          "description": "Show tracks that have been added to the queue.",
-          "options": {
-            "page": {
-              "name": "page",
-              "description": "Page number to display for the queue."
-            }
-          }
-        },
-        "tracksInQueueTitle": "{{icon}} **Tracks in queue**"
-      },
-      "reload": {
-        "metadata": {
-          "name": "reload",
-          "description": "Reload slash command, autocomplete and component interactions across shards."
-        },
-        "reloadedCommands": "{{icon}} **Reloaded commands**",
-        "unableToReload": "{{icon}} **Oops!**\n_Hmm..._ It seems I am unable to reload the interaction module across shards."
-      },
-      "remove": {
-        "noTracksRemoved": "{{icon}} **No tracks removed**\nThere were no tracks removed from the queue. Please check if the option you selected has tracks to remove.",
-        "removedTrack": "{{icon}} **Removed track**",
-        "removedTracks": "{{icon}} **Removed tracks**\n**`{{count}}`** tracks were removed from the queue.",
-        "startPositionHigherThanEndPosition": "{{icon}} **Oops!**\nStart position **`{{start}}`** is higher than end position **`{{end}}`**. Please specify a valid range.\n\nView tracks added to the queue with {{queueCommand}}.",
-        "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nPosition **`{{position}}`** is not a valid track position. There is only a total of **`1`** track in the queue.\n\nView the tracks added to the queue with {{queueCommand}}.",
-        "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nPosition **`{{position}}`** is not a valid track position. There are only a total of **`{{count}}`** tracks in the queue.\n\nView the tracks added to the queue with {{queueCommand}}."
-      },
-      "seek": {
-        "metadata": {
-          "name": "seek",
-          "description": "Seek to a position in the current track.",
-          "options": {
-            "duration": {
-              "name": "duration",
-              "description": "Timestamp in format 00:00:00 (HH:mm:ss)."
-            }
-          }
-        },
-        "correctFormatInstruction": "{{icon}} **Oops!**\nYou entered an invalid duration format, **`{{wrongDuration}}`**.\nPlease use the format **`HH:mm:ss`**, **`mm:ss`** or **`ss`**.\n\n**Examples:**\n- **`/seek`** **`1:24:12`** - Seek to 1 hour, 24 minutes and 12 seconds.\n- **`/seek`** **`3:27`** - Seek to 3 minutes and 27 seconds.\n- **`/seek`** **`42`** - Seek to 42 seconds.",
-        "durationLongerThanTrackDuration": "{{icon}} **Oops!**\nYou entered **`{{wrongDuration}}`**, which is a timestamp longer than the duration of the current track.\n\nPlease try a timestamp that is less than the duration of the track (**{{trackDuration}}**).",
-        "seekingToTimestamp": "{{icon}} **Seeking to timestamp**\nSeeking to **`{{duration}}`** in current track."
-      },
-      "shards": {
-        "metadata": {
-          "name": "shards",
-          "description": "Show information about all connected shards.",
-          "options": {
-            "sort": {
-              "name": "sort",
-              "description": "What to sort the shards by.",
-              "choices": {
-                "none": "None (Shard ID)",
-                "memory": "Memory usage",
-                "connections": "Voice Connections",
-                "tracks": "Tracks",
-                "listeners": "Listeners",
-                "guilds": "Guilds",
-                "members": "Members"
-              }
-            },
-            "page": {
-              "name": "page",
-              "description": "Page number to display for the shards."
-            }
-          }
-        }
-      },
-      "shuffle": {
-        "metadata": {
-          "name": "shuffle",
-          "description": "Randomly shuffle all tracks in the queue."
-        },
-        "shuffledTracks": "{{icon}} **Shuffled queue tracks**\nThe **{{count}}** tracks in the queue have been shuffled.\n\nView the new queue order with {{queueCommand}}."
-      },
-      "skip": {
-        "metadata": {
-          "name": "skip",
-          "description": "Skip track to next or specified position in queue.",
-          "options": {
-            "position": {
-              "name": "position",
-              "description": "The position in queue to skip to."
-            }
-          }
-        },
-        "emptyQueue": "{{icon}} **Oops!**\nThe queue is empty, add some tracks with {{playCommand}}!",
-        "skippedTrack": "{{icon}} **Skipped track**",
-        "trackPositionHigherThanQueueLength_one": "{{icon}} **Oops!**\nThere is only **1** track in the queue. You cannot skip to track **{{position}}**.\n\nView tracks added to the queue with {{queueCommand}}.",
-        "trackPositionHigherThanQueueLength": "{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the queue. You cannot skip to track **{{position}}**.\n\nView tracks added to the queue with {{queueCommand}}."
-      },
-      "status": {
-        "metadata": {
-          "name": "status",
-          "description": "Show operational status of the bot."
-        }
-      },
-      "stop": {
-        "metadata": {
-          "name": "stop",
-          "description": "Clear the queue and stop playing audio."
-        },
-        "stoppedPlaying": "{{icon}} **Stopped playing**\nStopped playing the audio and cleared the track queue.\n\nTo play more music, use the {{playCommand}} command!"
-      },
-      "systemstatus": {
-        "metadata": {
-          "name": "systemstatus",
-          "description": "Show operational status of the bot with additional technical information."
-        }
-      },
-      "volume": {
-        "metadata": {
-          "name": "volume",
-          "description": "Show or change the playback volume for tracks.",
-          "options": {
-            "percentage": {
-              "name": "percentage",
-              "description": "Volume percentage: From 1% to 100%."
-            }
-          }
-        },
-        "invalidVolumeRange": "{{icon}} **Oops!**\nYou cannot set the volume to **`{{wrongVolume}}%`**, please pick a value between **`1%`** and **`100%`**.",
-        "volumeChanged": "{{icon}} **Volume changed**\nPlayback volume has been changed to **`{{volume}}%`**.",
-        "volumeInformation": "{{icon}} **Playback volume**\nThe playback volume is currently set to **`{{volume}}`**.",
-        "volumeMuted": "{{icon}} **Audio muted**\nPlayback audio has been muted, because the volume was set to **`0%`**."
-      }
-    },
-    "musicPlayerCommon": {
-      "controls": {
-        "stop": "Stop",
-        "previous": "Previous",
-        "pause": "Pause",
-        "resume": "Resume",
-        "skip": "Skip"
-      },
-      "footerPageNumber_one": "Page {{page}} of {{pageCount}} (1 track)",
-      "footerPageNumber": "Page {{page}} of {{pageCount}} ({{count}} tracks)",
-      "loopingInfo": "{{icon}} **Looping**\nLoop mode is set to **`{{loopMode}}`**. You can change it with {{loopCommand}}.",
-      "nowPausedTitle": "{{icon}} **Currently paused**",
-      "nowPlayingTitle": "{{icon}} **Now playing**",
-      "playingLive": "{{icon}} **`LIVE`** - Playing continuously from live source.",
-      "queueRepeatMode": {
-        "off": "Disabled",
-        "track": "Track",
-        "queue": "Queue",
-        "autoplay": "Autoplay"
-      },
-      "requestedBy": "**Requested by:** {{user}}",
-      "unavailableAuthor": "Unavailable",
-      "unavailableDuration": "_No duration available._",
-      "unavailableRequestedBy": "Unavailable",
-      "unavailableTrackTitle": "Title unavailable",
-      "unavailableTrackUrl": "**Unavailable**",
-      "unavailableSource": "Unavailable",
-      "voiceChannelInfo": "Channel: {{channel}} ({{bitrate}}kbps)"
-    },
-    "statistics": {
-      "botStatus": {
-        "title": "{{icon}} **Bot status**",
-        "joinedServers": "**{{count}}** Joined servers",
-        "joinedServers_one": "**1** Joined server",
-        "totalMembers": "**{{count}}** Total members",
-        "releaseVersion": "**{{version}}** Release version"
-      },
-      "queueStatus": {
-        "title": "{{icon}} **Queue status**",
-        "voiceConnections": "**{{count}}** Voice connections",
-        "voiceConnections_one": "**1** Voice connection",
-        "tracksInQueues": "**{{count}}** Tracks in queues",
-        "tracksInQueues_one": "**1** Track in queues",
-        "usersListening": "**{{count}}** Users listening",
-        "usersListening_one": "**1** User listening"
-      },
-      "systemStatus": {
-        "title": "{{icon}} **System status**",
-        "uptime": "**{{value}}** Uptime",
-        "cpu": "**{{value, number(minimumFractionDigits: 2)}}%** CPU usage",
-        "cpuDetailed": "**{{usage}}% @ {{cores}} cores** CPU usage",
-        "memory": "**{{value, number}} MB** Memory usage",
-        "memoryDetailed": "**{{used, number}} / {{total, number}} MB** Memory usage",
-        "platform": "**{{value}}** Platform"
-      },
-      "discordStatus": {
-        "title": "{{icon}} **Discord status**",
-        "apiLatency": "**{{value, number}} ms** Discord API latency"
-      },
-      "dependencies": {
-        "title": "{{icon}} **Dependencies**"
-      }
-    },
-    "validation": {
-      "cannotJoinVoiceOrTalk": "{{icon}} **Oops!**\nI do not have permission to play audio in the voice channel {{channel}}.\n\nPlease make sure I have the **`Connect`** and **`Speak`** permissions in this voice channel.",
-      "cannotSendMessageInChannel": "{{icon}} **Oops!**\nI do not have permission to send message replies in the channel {{channel}}.\n\nPlease make sure I have the **`View Channel`** permission in this text channel.",
-      "historyDoesNotExist": "{{icon}} **Oops!**\nThere are no tracks in the history and nothing currently playing. First add some tracks with {{playCommand}}!",
-      "notInSameVoiceChannel": "{{icon}} **Not in same voice channel**\nYou need to be in the same voice channel as me to perform this action.\n\n**Voice channel:** {{channel}}",
-      "notInVoiceChannel": "{{icon}} **Not in a voice channel**\nYou need to be in a voice channel to perform this action.",
-      "notValidGuildId": "{{icon}} **Oops!**\nNo permission to perform this action.\n\nThe command {{command}} cannot be executed in this server.",
-      "queueDoesNotExist": "{{icon}} **Oops!**\nThere are no tracks in the queue and nothing currently playing. First add some tracks with {{playCommand}}!",
-      "queueIsEmpty": "{{icon}} **Oops!\nThere are no tracks added to the queue. First add some tracks with {{playCommand}}!",
-      "queueNoCurrentTrack": "{{icon}} **Oops!**\nThere is nothing currently playing. First add some tracks with {{playCommand}}!"
-    }
-  }
+    bot: {
+        autocomplete: {
+            trackName: '{{title}} [Author: {{author}}]';
+        };
+        commands: {
+            back: {
+                metadata: {
+                    name: 'back';
+                    description: 'Go back to previous track or specified position in history.';
+                    options: {
+                        position: {
+                            name: 'position';
+                            description: 'The position in history to go back to.';
+                        };
+                    };
+                };
+                trackHistoryEmpty: '{{icon}} **Oops!**\nThe history is empty, add some tracks with {{playCommand}}!';
+                trackPositionHigherThanHistoryLength_one: '{{icon}} **Oops!**\nThere is only **1** track in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.';
+                trackPositionHigherThanHistoryLength: '{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the history. You cannot go back to track **{{backPosition}}**.\n\nView tracks added in the history with {{historyCommand}}.';
+                trackRecovered: '{{icon}} **Recovered track**\n{{track}}';
+            };
+            filters: {
+                metadata: {
+                    name: 'filters';
+                    description: 'Toggle various audio filters.';
+                    options: {
+                        type: {
+                            name: 'type';
+                            description: 'Audio filter type to use.';
+                            choices: {
+                                ffmpeg: 'FFmpeg';
+                                biquad: 'Biquad';
+                                equalizer: 'Equalizer';
+                                disable: 'Disable';
+                            };
+                        };
+                    };
+                };
+                allFiltersDisabled: '{{icon}} **Disabled filters**\nAll audio filters have been disabled.';
+                disableAllFiltersButton: 'Disable all filters';
+                nowUsingFilters: '{{icon}} **Filters toggled**\nNow using these {{mode}} filters:';
+                selectFilterPlaceholder: 'Select a filter from the menu.';
+                selectFilterPlaceholderMany: 'Select one or multiple filters.';
+                toggleFilterInstructions: '**Toggle filters ({{provider}})**\nEnable or disable audio filters for playback from the menu.';
+            };
+            guilds: {
+                metadata: {
+                    name: 'guilds';
+                    description: 'Show the top 25 guilds by member count.';
+                };
+                topGuildsByMemberCount: '{{icon}} **Top {{count}} guilds by member count ({{totalCount}} total)**';
+                totalMembers: '**Total members:** **`{{count}`**';
+            };
+            help: {
+                metadata: {
+                    name: 'help';
+                    description: 'Show the list of bot commands.';
+                };
+                addBotButton: 'Add bot';
+                listTitle: '{{icon}} **List of commands**';
+                supportServerButton: 'Support server';
+            };
+            history: {
+                metadata: {
+                    name: 'history';
+                    description: 'Show history of tracks that have been played.';
+                    options: {
+                        page: {
+                            name: 'page';
+                            description: 'Page number to display for the history.';
+                        };
+                    };
+                };
+                emptyHistory: 'The history is empty, add some tracks with {{playCommand}}!';
+                invalidPageNumber_one: '{{icon}} **Oops!**\nPage **`{{page}}`** is not a valid page number.\n\nThere is only **`1`** page in the history.';
+                invalidPageNumber: '{{icon}} **Oops!**\nPage **`{{page}}`** is not a valid page number.\n\nThere are only a total of **`{{count}}`** pages in the history.';
+                tracksInHistoryTitle: '{{icon}} **Tracks in history**';
+            };
+            join: {
+                metadata: {
+                    name: 'join';
+                    description: 'The bot will join the voice channel if not already in one.';
+                };
+                alreadyConnected: '{{icon}} **Oops!**\nI am already connected to the {{channel}} voice channel.\n\nTo disconnect me from the channel, use the {{leaveCommand}} command.';
+                couldNotJoin: '{{icon}} **Oops!**\nCould not join voice channel, please try again.';
+                joinedChannel: '{{icon}} **Joined channel**\nConnected to voice channel: {{channel}}\n\nTo add tracks, use the {{playCommand}} command!';
+            };
+            leave: {
+                metadata: {
+                    name: 'leave';
+                    description: 'Clear the queue and remove bot from voice channel.';
+                };
+                leavingChannel: '{{icon}} **Leaving channel**\nCleared the track queue and left voice channel.\n\nTo play more music, use the {{playCommand}} command!';
+            };
+            loop: {
+                metadata: {
+                    name: 'loop';
+                    description: 'Toggle looping a track, the whole queue or autoplay.';
+                    options: {
+                        mode: {
+                            name: 'mode';
+                            description: 'Loop mode: Track, queue, autoplay or disabled.';
+                            choices: {
+                                '0': 'Off';
+                                '1': 'Track';
+                                '2': 'Queue';
+                                '3': 'Autoplay';
+                            };
+                        };
+                    };
+                };
+                alreadySet: '{{icon}} **Oops!**\nLoop mode is already **`{{mode}}`**.';
+                loopModeInformation: '{{icon}} **Current loop mode**\nThe looping mode is currently set to **`{{mode}}`**.';
+                modeChanged: '{{icon}} **Loop mode changed**\nChanging loop mode from **`{{fromName}}`** to **`{{toName}}`**.';
+                willAutoplay: 'When the queue is empty, similar tracks will start playing!';
+                willNoLongerPlay: 'The {{mode}} will no longer play on repeat!';
+                willNowPlay: 'The {{mode}} will now play on repeat!';
+            };
+            lyrics: {
+                metadata: {
+                    name: 'lyrics';
+                    description: 'Search Genius lyrics for current or specified track.';
+                    options: {
+                        query: {
+                            name: 'query';
+                            description: 'Search query by text or URL.';
+                        };
+                    };
+                };
+                autocompleteSearchResult: '{{title}} [Artist: {{artist}}]';
+                lyricsEmbed: '{{icon}} **Showing lyrics**\n**Track: [{{trackTitle}}]({{trackUrl}})**\n**Artist: [{{artistName}}]({{artistUrl}})**';
+                noLyricsFound: '{{icon}} **No lyrics found**\nThere were no Genius lyrics found for track **{{query}}**.';
+            };
+            move: {
+                metadata: {
+                    name: 'move';
+                    description: 'Move a track to a specified position in queue.';
+                    options: {
+                        from: {
+                            name: 'from';
+                            description: 'The position of the track to move.';
+                        };
+                        to: {
+                            name: 'to';
+                            description: 'The position to move the track to.';
+                        };
+                    };
+                };
+                trackMoved: '{{icon}} **Moved track**\n{track}\n\nTrack has been moved from position **`{{fromPosition}}`** to position **`{{toPosition}}`**.';
+                trackPositionHigherThanQueueLength_one: '{{icon}} **Oops!**\nYou cannot move the track in position **`{{fromPosition}}`** to position **`{{toPosition}}`**. There is only **`1`** track in the queue.\n\nView tracks added to the queue with {{queueCommand}}.';
+                trackPositionHigherThanQueueLength: '{{icon}} **Oops!**\nYou cannot move the track in position **`{{fromPosition}}`** to position **`{{toPosition}}`**. There are only **`{{count}}`** tracks in the queue.\n\nView tracks added to the queue with {{queueCommand}}.';
+            };
+            nowplaying: {
+                metadata: {
+                    name: 'nowplaying';
+                    description: 'Show information about the current track.';
+                };
+                embedFields: {
+                    author: '**Artist**';
+                    plays: '**Plays**';
+                    source: '**Track source**';
+                };
+                otherTracksInQueue_one: '1 other track in the queue...';
+                otherTracksInQueue: '{{count}} other tracks in the queue...';
+                playCount_zero: 'Unknown';
+                playCount: '{{count, number}}';
+            };
+            pause: {
+                metadata: {
+                    name: 'pause';
+                    description: 'Toggle pause for the current track.';
+                };
+                pauseConfirmation: '{{icon}} **Paused track**';
+                resumeConfirmation: '{{icon}} **Resumed track**';
+                directSource: 'Direct source';
+            };
+            play: {
+                metadata: {
+                    name: 'play';
+                    description: 'Add a track or playlist to the queue by search query or URL.';
+                    options: {
+                        query: {
+                            name: 'query';
+                            description: 'Search query by text or URL.';
+                        };
+                    };
+                };
+                addedToQueueTitle: '{{icon}} **Added to queue**';
+                playlistAddedTitle: '{{icon}} **Added playlist to queue**';
+                playlistAddedTrackCount_one: 'And **1** more track... Use {{queueCommand}} to view all.';
+                playlistAddedTrackCount: 'And **{{count}}** more tracks... Use {{queueCommand}} to view all.';
+                playlistTooLarge: '{{icon}} **Playlist too large**\nThis playlist is too large to be added to the queue.\n\nThe maximum amount of tracks that can be added to the queue is **{{count}}**.';
+                trackNotFound: '{{icon}} **No track found\nNo results found for **{{query}}**.\n\nIf you specified a URL, please make sure it is valid and public.';
+            };
+            queue: {
+                metadata: {
+                    name: 'queue';
+                    description: 'Show tracks that have been added to the queue.';
+                    options: {
+                        page: {
+                            name: 'page';
+                            description: 'Page number to display for the queue.';
+                        };
+                    };
+                };
+                tracksInQueueTitle: '{{icon}} **Tracks in queue**';
+                emptyQueue: 'The queue is empty, add some tracks with {{playCommand}}!';
+                estimatedDuration: 'Estimated duration: {{duration}}';
+                estimatedReallyLongTime: 'Estimated duration: A really long time';
+                invalidPageNumber_one: '{{icon}} **Oops!**\nPage **`{{page}}`** is not a valid page number.\n\nThere is only **`1`** page in the queue.';
+                invalidPageNumber: '{{icon}} **Oops!**\nPage **`{{page}}`** is not a valid page number.\n\nThere are only a total of **`{{count}}`** pages in the queue.';
+            };
+            reload: {
+                metadata: {
+                    name: 'reload';
+                    description: 'Reload slash command, autocomplete and component interactions across shards.';
+                };
+                reloadedCommands: '{{icon}} **Reloaded commands**';
+                unableToReload: '{{icon}} **Oops!**\n_Hmm..._ It seems I am unable to reload the interaction module across shards.';
+            };
+            remove: {
+                noTracksRemoved: '{{icon}} **No tracks removed**\nThere were no tracks removed from the queue. Please check if the option you selected has tracks to remove.';
+                removedTrack: '{{icon}} **Removed track**';
+                removedTracks: '{{icon}} **Removed tracks**\n**`{{count}}`** tracks were removed from the queue.';
+                startPositionHigherThanEndPosition: '{{icon}} **Oops!**\nStart position **`{{start}}`** is higher than end position **`{{end}}`**. Please specify a valid range.\n\nView tracks added to the queue with {{queueCommand}}.';
+                trackPositionHigherThanQueueLength_one: '{{icon}} **Oops!**\nPosition **`{{position}}`** is not a valid track position. There is only a total of **`1`** track in the queue.\n\nView the tracks added to the queue with {{queueCommand}}.';
+                trackPositionHigherThanQueueLength: '{{icon}} **Oops!**\nPosition **`{{position}}`** is not a valid track position. There are only a total of **`{{count}}`** tracks in the queue.\n\nView the tracks added to the queue with {{queueCommand}}.';
+            };
+            seek: {
+                metadata: {
+                    name: 'seek';
+                    description: 'Seek to a position in the current track.';
+                    options: {
+                        duration: {
+                            name: 'duration';
+                            description: 'Timestamp in format 00:00:00 (HH:mm:ss).';
+                        };
+                    };
+                };
+                correctFormatInstruction: '{{icon}} **Oops!**\nYou entered an invalid duration format, **`{{wrongDuration}}`**.\nPlease use the format **`HH:mm:ss`**, **`mm:ss`** or **`ss`**.\n\n**Examples:**\n- **`/seek`** **`1:24:12`** - Seek to 1 hour, 24 minutes and 12 seconds.\n- **`/seek`** **`3:27`** - Seek to 3 minutes and 27 seconds.\n- **`/seek`** **`42`** - Seek to 42 seconds.';
+                durationLongerThanTrackDuration: '{{icon}} **Oops!**\nYou entered **`{{wrongDuration}}`**, which is a timestamp longer than the duration of the current track.\n\nPlease try a timestamp that is less than the duration of the track (**{{trackDuration}}**).';
+                seekingToTimestamp: '{{icon}} **Seeking to timestamp**\nSeeking to **`{{duration}}`** in current track.';
+            };
+            shards: {
+                metadata: {
+                    name: 'shards';
+                    description: 'Show information about all connected shards.';
+                    options: {
+                        sort: {
+                            name: 'sort';
+                            description: 'What to sort the shards by.';
+                            choices: {
+                                none: 'None (Shard ID)';
+                                memory: 'Memory usage';
+                                connections: 'Voice Connections';
+                                tracks: 'Tracks';
+                                listeners: 'Listeners';
+                                guilds: 'Guilds';
+                                members: 'Members';
+                            };
+                        };
+                        page: {
+                            name: 'page';
+                            description: 'Page number to display for the shards.';
+                        };
+                    };
+                };
+            };
+            shuffle: {
+                metadata: {
+                    name: 'shuffle';
+                    description: 'Randomly shuffle all tracks in the queue.';
+                };
+                shuffledTracks: '{{icon}} **Shuffled queue tracks**\nThe **{{count}}** tracks in the queue have been shuffled.\n\nView the new queue order with {{queueCommand}}.';
+            };
+            skip: {
+                metadata: {
+                    name: 'skip';
+                    description: 'Skip track to next or specified position in queue.';
+                    options: {
+                        position: {
+                            name: 'position';
+                            description: 'The position in queue to skip to.';
+                        };
+                    };
+                };
+                emptyQueue: '{{icon}} **Oops!**\nThe queue is empty, add some tracks with {{playCommand}}!';
+                skippedTrack: '{{icon}} **Skipped track**';
+                trackPositionHigherThanQueueLength_one: '{{icon}} **Oops!**\nThere is only **1** track in the queue. You cannot skip to track **{{position}}**.\n\nView tracks added to the queue with {{queueCommand}}.';
+                trackPositionHigherThanQueueLength: '{{icon}} **Oops!**\nThere are only **{{count}}** tracks in the queue. You cannot skip to track **{{position}}**.\n\nView tracks added to the queue with {{queueCommand}}.';
+            };
+            status: {
+                metadata: {
+                    name: 'status';
+                    description: 'Show operational status of the bot.';
+                };
+            };
+            stop: {
+                metadata: {
+                    name: 'stop';
+                    description: 'Clear the queue and stop playing audio.';
+                };
+                stoppedPlaying: '{{icon}} **Stopped playing**\nStopped playing the audio and cleared the track queue.\n\nTo play more music, use the {{playCommand}} command!';
+            };
+            systemstatus: {
+                metadata: {
+                    name: 'systemstatus';
+                    description: 'Show operational status of the bot with additional technical information.';
+                };
+            };
+            volume: {
+                metadata: {
+                    name: 'volume';
+                    description: 'Show or change the playback volume for tracks.';
+                    options: {
+                        percentage: {
+                            name: 'percentage';
+                            description: 'Volume percentage: From 1% to 100%.';
+                        };
+                    };
+                };
+                invalidVolumeRange: '{{icon}} **Oops!**\nYou cannot set the volume to **`{{wrongVolume}}%`**, please pick a value between **`1%`** and **`100%`**.';
+                volumeChanged: '{{icon}} **Volume changed**\nPlayback volume has been changed to **`{{volume}}%`**.';
+                volumeInformation: '{{icon}} **Playback volume**\nThe playback volume is currently set to **`{{volume}}`**.';
+                volumeMuted: '{{icon}} **Audio muted**\nPlayback audio has been muted, because the volume was set to **`0%`**.';
+            };
+        };
+        musicPlayerCommon: {
+            controls: {
+                stop: 'Stop';
+                previous: 'Previous';
+                pause: 'Pause';
+                resume: 'Resume';
+                skip: 'Skip';
+            };
+            footerPageNumber_one: 'Page {{page}} of {{pageCount}} (1 track)';
+            footerPageNumber: 'Page {{page}} of {{pageCount}} ({{count}} tracks)';
+            loopingInfo: '{{icon}} **Looping**\nLoop mode is set to **`{{loopMode}}`**. You can change it with {{loopCommand}}.';
+            nowPausedTitle: '{{icon}} **Currently paused**';
+            nowPlayingTitle: '{{icon}} **Now playing**';
+            playingLive: '{{icon}} **`LIVE`** - Playing continuously from live source.';
+            queueRepeatMode: {
+                off: 'Disabled';
+                track: 'Track';
+                queue: 'Queue';
+                autoplay: 'Autoplay';
+            };
+            requestedBy: '**Requested by:** {{user}}';
+            unavailableAuthor: 'Unavailable';
+            unavailableDuration: '_No duration available._';
+            unavailableRequestedBy: 'Unavailable';
+            unavailableTrackTitle: 'Title unavailable';
+            unavailableTrackUrl: '**Unavailable**';
+            unavailableSource: 'Unavailable';
+            voiceChannelInfo: 'Channel: {{channel}} ({{bitrate}}kbps)';
+        };
+        statistics: {
+            botStatus: {
+                title: '{{icon}} **Bot status**';
+                joinedServers: '**{{count}}** Joined servers';
+                joinedServers_one: '**1** Joined server';
+                totalMembers: '**{{count}}** Total members';
+                releaseVersion: '**{{version}}** Release version';
+            };
+            queueStatus: {
+                title: '{{icon}} **Queue status**';
+                voiceConnections: '**{{count}}** Voice connections';
+                voiceConnections_one: '**1** Voice connection';
+                tracksInQueues: '**{{count}}** Tracks in queues';
+                tracksInQueues_one: '**1** Track in queues';
+                usersListening: '**{{count}}** Users listening';
+                usersListening_one: '**1** User listening';
+            };
+            systemStatus: {
+                title: '{{icon}} **System status**';
+                uptime: '**{{value}}** Uptime';
+                cpu: '**{{value, number(minimumFractionDigits: 2)}}%** CPU usage';
+                cpuDetailed: '**{{usage}}% @ {{cores}} cores** CPU usage';
+                memory: '**{{value, number}} MB** Memory usage';
+                memoryDetailed: '**{{used, number}} / {{total, number}} MB** Memory usage';
+                platform: '**{{value}}** Platform';
+            };
+            discordStatus: {
+                title: '{{icon}} **Discord status**';
+                apiLatency: '**{{value, number}} ms** Discord API latency';
+            };
+            dependencies: {
+                title: '{{icon}} **Dependencies**';
+            };
+        };
+        validation: {
+            cannotJoinVoiceOrTalk: '{{icon}} **Oops!**\nI do not have permission to play audio in the voice channel {{channel}}.\n\nPlease make sure I have the **`Connect`** and **`Speak`** permissions in this voice channel.';
+            cannotSendMessageInChannel: '{{icon}} **Oops!**\nI do not have permission to send message replies in the channel {{channel}}.\n\nPlease make sure I have the **`View Channel`** permission in this text channel.';
+            historyDoesNotExist: '{{icon}} **Oops!**\nThere are no tracks in the history and nothing currently playing. First add some tracks with {{playCommand}}!';
+            notInSameVoiceChannel: '{{icon}} **Not in same voice channel**\nYou need to be in the same voice channel as me to perform this action.\n\n**Voice channel:** {{channel}}';
+            notInVoiceChannel: '{{icon}} **Not in a voice channel**\nYou need to be in a voice channel to perform this action.';
+            notValidGuildId: '{{icon}} **Oops!**\nNo permission to perform this action.\n\nThe command {{command}} cannot be executed in this server.';
+            queueDoesNotExist: '{{icon}} **Oops!**\nThere are no tracks in the queue and nothing currently playing. First add some tracks with {{playCommand}}!';
+            queueIsEmpty: '{{icon}} **Oops!\nThere are no tracks added to the queue. First add some tracks with {{playCommand}}!';
+            queueNoCurrentTrack: '{{icon}} **Oops!**\nThere is nothing currently playing. First add some tracks with {{playCommand}}!';
+        };
+    };
 }
 
 export default Resources;

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -57,9 +57,9 @@ interface Resources {
           "name": "help",
           "description": "Show the list of bot commands."
         },
-        "addBotCallout": "{{icon}} **Enjoying {{botName}}?**\nAdd me to another server:\n**[Click me!]({{invite}})**",
+        "addBotButton": "Add bot",
         "listTitle": "{{icon}} **List of commands**",
-        "supportServerCallout": "{{icon}} **Support server**\nJoin the support server for help or to suggest improvements:\n{{invite}}"
+        "supportServerButton": "Support server"
       },
       "history": {
         "metadata": {

--- a/locales/resources.d.ts
+++ b/locales/resources.d.ts
@@ -326,6 +326,12 @@ interface Resources {
                 volumeMuted: '{{icon}} **Audio muted**\nPlayback audio has been muted, because the volume was set to **`0%`**.';
             };
         };
+        components: {
+            responses: {
+                paused: 'Paused track';
+                resumed: 'Resumed track';
+            };
+        };
         musicPlayerCommon: {
             controls: {
                 stop: 'Stop';
@@ -399,6 +405,7 @@ interface Resources {
             queueDoesNotExist: '{{icon}} **Oops!**\nThere are no tracks in the queue and nothing currently playing. First add some tracks with {{playCommand}}!';
             queueIsEmpty: '{{icon}} **Oops!\nThere are no tracks added to the queue. First add some tracks with {{playCommand}}!';
             queueNoCurrentTrack: '{{icon}} **Oops!**\nThere is nothing currently playing. First add some tracks with {{playCommand}}!';
+            trackNotPlayingAnymore: '{{icon}} **Oops!**\nThis track has been skipped or is no longer playing.';
         };
     };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
                 "discord-voip": "^0.1.3",
                 "discord.js": "^14.14.1",
                 "dotenv": "^16.3.1",
+                "i18next": "^23.7.9",
+                "i18next-fs-backend": "^2.3.1",
                 "mediaplex": "^0.0.9",
                 "node-os-utils": "^1.3.7",
                 "pino": "^8.16.2",
@@ -34,6 +36,7 @@
                 "eslint": "^8.55.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.0.1",
+                "i18next-resources-for-ts": "^1.4.0",
                 "jest": "^29.7.0",
                 "prettier": "^3.1.1",
                 "ts-jest": "^29.1.1",
@@ -645,6 +648,17 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
+            "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
+            "dependencies": {
+                "regenerator-runtime": "^0.14.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
@@ -4036,6 +4050,45 @@
                 "node": ">=10.17.0"
             }
         },
+        "node_modules/i18next": {
+            "version": "23.7.11",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.7.11.tgz",
+            "integrity": "sha512-A/vOkw8vY99YHU9A1Td3I1dcTiYaPnwBWzrpVzfXUXSYgogK3cmBcmop/0cnXPc6QpUWIyqaugKNxRUEZVk9Nw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://locize.com"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://locize.com/i18next.html"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                }
+            ],
+            "dependencies": {
+                "@babel/runtime": "^7.23.2"
+            }
+        },
+        "node_modules/i18next-fs-backend": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.3.1.tgz",
+            "integrity": "sha512-tvfXskmG/9o+TJ5Fxu54sSO5OkY6d+uMn+K6JiUGLJrwxAVfer+8V3nU8jq3ts9Pe5lXJv4b1N7foIjJ8Iy2Gg=="
+        },
+        "node_modules/i18next-resources-for-ts": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/i18next-resources-for-ts/-/i18next-resources-for-ts-1.4.0.tgz",
+            "integrity": "sha512-NesjHO2/4/ogSl5JPD5r1YnfsJLop0J9CKfxCEuwSLNoJY3o7HhXSpnOMFI3HavlyWtKvX9u0XB8qnWBq684pQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.23.2"
+            },
+            "bin": {
+                "i18next-resources-for-ts": "bin/i18next-resources-for-ts.js"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -6144,6 +6197,11 @@
             "engines": {
                 "node": ">= 12.13.0"
             }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
         },
         "node_modules/require-directory": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,13 @@
         "build": "tsc",
         "toc": "i18next-resources-for-ts interface -i ./locales/en -o ./locales/resources.d.ts"
     },
+    "nodemonConfig": {
+        "ignore": [
+            "src/**",
+            "logs/**"
+        ],
+        "execMap": {}
+    },
     "dependencies": {
         "@discord-player/extractor": "^4.4.5",
         "@discord-player/opus": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "deploy": "node ./dist/utils/deploySlashCommands.js",
         "deploy-pretty": "node ./dist/utils/deploySlashCommands.js | pino-pretty --ignore environment,source,module,action,name,context,executionId,executionTime,shardId,guildId,interactionType",
         "eslint": "eslint ./src",
-        "build": "tsc"
+        "build": "tsc",
+        "toc": "i18next-resources-for-ts interface -i ./locales/en -o ./locales/resources.d.ts"
     },
     "dependencies": {
         "@discord-player/extractor": "^4.4.5",
@@ -45,6 +46,8 @@
         "discord-voip": "^0.1.3",
         "discord.js": "^14.14.1",
         "dotenv": "^16.3.1",
+        "i18next": "^23.7.9",
+        "i18next-fs-backend": "^2.3.1",
         "mediaplex": "^0.0.9",
         "node-os-utils": "^1.3.7",
         "pino": "^8.16.2",
@@ -62,6 +65,7 @@
         "eslint": "^8.55.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.0.1",
+        "i18next-resources-for-ts": "^1.4.0",
         "jest": "^29.7.0",
         "prettier": "^3.1.1",
         "ts-jest": "^29.1.1",

--- a/src/classes/interactions.ts
+++ b/src/classes/interactions.ts
@@ -27,7 +27,6 @@ import {
 } from '../types/interactionTypes';
 import { Validator, ValidatorParams } from '../types/utilTypes';
 import { TFunction } from 'i18next';
-import { formatSlashCommand } from '../common/formattingUtils';
 
 abstract class BaseInteraction {
     embedOptions: EmbedOptions;
@@ -160,34 +159,6 @@ abstract class BaseInteraction {
         }
 
         return progressBar;
-    }
-
-    protected getDisplayRepeatMode(repeatMode: number, translator: TFunction, state: string = 'info'): string {
-        let loopModeUserString: string;
-        let icon: string;
-
-        switch (repeatMode) {
-            case 1:
-                loopModeUserString = 'track';
-                icon = state === 'info' ? this.embedOptions.icons.loop : this.embedOptions.icons.looping;
-                break;
-            case 2:
-                loopModeUserString = 'queue';
-                icon = state === 'info' ? this.embedOptions.icons.loop : this.embedOptions.icons.looping;
-                break;
-            case 3:
-                loopModeUserString = 'autoplay';
-                icon = state === 'info' ? this.embedOptions.icons.autoplay : this.embedOptions.icons.autoplaying;
-                break;
-            default:
-                return '';
-        }
-
-        return translator('musicPlayerCommon.loopingInfo', {
-            icon,
-            loopMode: loopModeUserString,
-            loopCommand: formatSlashCommand('loop', translator)
-        });
     }
 
     abstract execute(

--- a/src/classes/interactions.ts
+++ b/src/classes/interactions.ts
@@ -26,6 +26,8 @@ import {
     BaseSlashCommandReturnType
 } from '../types/interactionTypes';
 import { Validator, ValidatorParams } from '../types/utilTypes';
+import { TFunction } from 'i18next';
+import { formatSlashCommand } from '../common/formattingUtils';
 
 abstract class BaseInteraction {
     embedOptions: EmbedOptions;
@@ -72,18 +74,18 @@ abstract class BaseInteraction {
         return durationFormat;
     }
 
-    protected getFormattedTrackUrl(track: Track): string {
-        const trackTitle = track.title ?? 'Title unavailable';
+    protected getFormattedTrackUrl(track: Track, translator: TFunction): string {
+        const trackTitle = track.title ?? translator('musicPlayerCommon.unavailableTrackTitle');
         const trackUrl = track.url ?? track.raw.url;
         if (!trackTitle || !trackUrl) {
-            return '**Unavailable**';
+            return translator('musicPlayerCommon.unavailableTrackUrl');
         }
         return `**[${trackTitle}](${trackUrl})**`;
     }
 
-    protected getDisplayTrackDurationAndUrl(track: Track): string {
+    protected getDisplayTrackDurationAndUrl(track: Track, translator: TFunction): string {
         const formattedDuration = this.getFormattedDuration(track);
-        const formattedUrl = this.getFormattedTrackUrl(track);
+        const formattedUrl = this.getFormattedTrackUrl(track, translator);
 
         return `${formattedDuration} ${formattedUrl}`;
     }
@@ -116,24 +118,27 @@ abstract class BaseInteraction {
 
     protected getFooterDisplayPageInfo(
         interaction: ChatInputCommandInteraction,
-        queue: GuildQueue | GuildQueueHistory
+        queue: GuildQueue | GuildQueueHistory,
+        translator: TFunction
     ): EmbedFooterData {
-        if (!queue.tracks.data.length) {
-            return { text: 'Page 1 of 1 (0 tracks)' };
-        }
-
         const pageIndex: number = (interaction.options.getInteger('page') || 1) - 1;
         const totalPages: number = Math.ceil(queue.tracks.data.length / 10) || 1;
         return {
-            text: `Page ${pageIndex + 1} of ${totalPages} (${queue.tracks.data.length} tracks)`
+            text: translator('musicPlayerCommon.footerPageNumber', {
+                page: pageIndex + 1,
+                pageCount: totalPages,
+                count: queue.tracks.data.length
+            })
         };
     }
 
-    protected getDisplayTrackRequestedBy = (track: Track): string => {
-        return track.requestedBy ? `<@${track.requestedBy.id}>` : 'Unavailable';
+    protected getDisplayTrackRequestedBy = (track: Track, translator: TFunction): string => {
+        return track.requestedBy
+            ? `<@${track.requestedBy.id}>`
+            : translator('musicPlayerCommon.unavailableRequestedBy');
     };
 
-    protected getDisplayQueueProgressBar(queue: GuildQueue): string {
+    protected getDisplayQueueProgressBar(queue: GuildQueue, translator: TFunction): string {
         const timestamp: PlayerTimestamp = queue.node.getTimestamp()!;
         let progressBar: string = `**\`${timestamp.current.label}\`** ${queue.node.createProgressBar({
             queue: false,
@@ -145,17 +150,19 @@ abstract class BaseInteraction {
         })} **\`${timestamp.total.label}\`**`;
 
         if (Number(queue.currentTrack?.raw.duration) === 0 || queue.currentTrack?.duration === '0:00') {
-            progressBar = '_No duration available._';
+            progressBar = translator('musicPlayerCommon.unavailableDuration');
         }
 
         if (queue.currentTrack?.raw.live) {
-            progressBar = `${this.embedOptions.icons.liveTrack} **\`LIVE\`** - Playing continuously from live source.`;
+            progressBar = translator('musicPlayerCommon.playingLive', {
+                icon: this.embedOptions.icons.liveTrack
+            });
         }
 
         return progressBar;
     }
 
-    protected getDisplayRepeatMode(repeatMode: number, state: string = 'info'): string {
+    protected getDisplayRepeatMode(repeatMode: number, translator: TFunction, state: string = 'info'): string {
         let loopModeUserString: string;
         let icon: string;
 
@@ -176,10 +183,11 @@ abstract class BaseInteraction {
                 return '';
         }
 
-        return (
-            `**${icon} Looping**\n` +
-            `Loop mode is set to **\`${loopModeUserString}\`**. You can change it with **\`/loop\`**.\n\n`
-        );
+        return translator('musicPlayerCommon.loopingInfo', {
+            icon,
+            loopMode: loopModeUserString,
+            loopCommand: formatSlashCommand('loop', translator)
+        });
     }
 
     abstract execute(
@@ -210,11 +218,15 @@ abstract class BaseInteractionWithEmbedResponse extends BaseInteraction {
 
     protected getEmbedQueueAuthor(
         interaction: MessageComponentInteraction | ChatInputCommandInteraction,
-        queue: GuildQueue
+        queue: GuildQueue,
+        translator: TFunction
     ): EmbedAuthorOptions {
         const bitrate = queue.channel ? queue.channel.bitrate / 1000 : 0;
         return {
-            name: `Channel: ${queue.channel!.name} (${bitrate}kbps)`,
+            name: translator('musicPlayerCommon.voiceChannelInfo', {
+                channel: queue.channel!.name,
+                bitrate
+            }),
             iconURL: interaction.guild!.iconURL() || this.embedOptions.info.fallbackIconUrl
         };
     }

--- a/src/common/autocompleteUtils.ts
+++ b/src/common/autocompleteUtils.ts
@@ -1,4 +1,5 @@
 import { Track } from 'discord-player';
+import { TFunction } from 'i18next';
 
 export function shouldUseLastQuery(query: string, lastQuery?: string, timestamp?: number): boolean {
     return Boolean(
@@ -10,7 +11,10 @@ export function isQueryTooShort(query: string): boolean {
     return query.length < 3;
 }
 
-export function getTrackName(track: Track): string {
-    const name = `${track.title} [Author: ${track.author}]`;
+export function getTrackName(track: Track, translator: TFunction): string {
+    const name = translator('autocomplete.trackName', {
+        title: track.title,
+        author: track.author
+    });
     return name.length > 100 ? name.slice(0, 100) : name;
 }

--- a/src/common/formattingUtils.ts
+++ b/src/common/formattingUtils.ts
@@ -1,4 +1,6 @@
+import { QueueRepeatMode } from 'discord-player';
 import { TFunction } from 'i18next';
+import { EmbedOptions } from '../types/configTypes';
 
 export function formatDuration(durationMs: number): string {
     const durationDate: Date = new Date(0);
@@ -25,4 +27,46 @@ export function formatSlashCommand(commandName: string, translator: TFunction): 
         defaultValue: commandName
     });
     return `**\`/${translatedName}\`**`;
+}
+
+export function formatRepeatMode(repeatMode: QueueRepeatMode, translator: TFunction): string {
+    switch (repeatMode) {
+        case QueueRepeatMode.AUTOPLAY:
+            return translator('musicPlayerCommon.queueRepeatMode.autoplay');
+        case QueueRepeatMode.OFF:
+            return translator('musicPlayerCommon.queueRepeatMode.off');
+        case QueueRepeatMode.TRACK:
+            return translator('musicPlayerCommon.queueRepeatMode.track');
+        case QueueRepeatMode.QUEUE:
+            return translator('musicPlayerCommon.queueRepeatMode.queue');
+    }
+}
+
+export function formatRepeatModeDetailed(
+    repeatMode: QueueRepeatMode,
+    embedOptions: EmbedOptions,
+    translator: TFunction,
+    state: string = 'info'
+) {
+    let icon: string;
+
+    switch (repeatMode) {
+        case QueueRepeatMode.TRACK:
+            icon = state === 'info' ? embedOptions.icons.loop : embedOptions.icons.looping;
+            break;
+        case QueueRepeatMode.QUEUE:
+            icon = state === 'info' ? embedOptions.icons.loop : embedOptions.icons.looping;
+            break;
+        case QueueRepeatMode.AUTOPLAY:
+            icon = state === 'info' ? embedOptions.icons.autoplay : embedOptions.icons.autoplaying;
+            break;
+        default:
+            return '';
+    }
+
+    return translator('musicPlayerCommon.loopingInfo', {
+        icon,
+        loopMode: formatRepeatMode(repeatMode, translator),
+        loopCommand: formatSlashCommand('loop', translator)
+    });
 }

--- a/src/common/formattingUtils.ts
+++ b/src/common/formattingUtils.ts
@@ -1,3 +1,5 @@
+import { TFunction } from 'i18next';
+
 export function formatDuration(durationMs: number): string {
     const durationDate: Date = new Date(0);
     durationDate.setMilliseconds(durationMs);
@@ -16,4 +18,11 @@ export function formatDuration(durationMs: number): string {
     } else {
         return `${durationSeconds}s`;
     }
+}
+
+export function formatSlashCommand(commandName: string, translator: TFunction): string {
+    const translatedName = translator(`commands.${commandName}.metadata.name`, {
+        defaultValue: commandName
+    });
+    return `**\`/${translatedName}\`**`;
 }

--- a/src/common/formattingUtils.ts
+++ b/src/common/formattingUtils.ts
@@ -64,9 +64,12 @@ export function formatRepeatModeDetailed(
             return '';
     }
 
-    return translator('musicPlayerCommon.loopingInfo', {
-        icon,
-        loopMode: formatRepeatMode(repeatMode, translator),
-        loopCommand: formatSlashCommand('loop', translator)
-    });
+    return (
+        '\n' +
+        translator('musicPlayerCommon.loopingInfo', {
+            icon,
+            loopMode: formatRepeatMode(repeatMode, translator),
+            loopCommand: formatSlashCommand('loop', translator)
+        })
+    );
 }

--- a/src/common/localeUtil.ts
+++ b/src/common/localeUtil.ts
@@ -122,6 +122,7 @@ export function localizeCommand(command: Omit<SlashCommandBuilder, 'addSubcomman
                 const localeOptionData = (
                     translatorInstance.getResource(locale, 'bot', metadataKey) as CommandMetadata | undefined
                 )?.options?.[option.name];
+
                 if (locale.startsWith('en') || !localeOptionData) {
                     continue;
                 }
@@ -131,7 +132,11 @@ export function localizeCommand(command: Omit<SlashCommandBuilder, 'addSubcomman
                 if (localeOptionData.description) {
                     option.description_localizations[locale] = localeOptionData.description;
                 }
-                if (localeOptionData.choices && option.type === ApplicationCommandOptionType.String && option.choices) {
+                if (
+                    localeOptionData.choices &&
+                    option.type === (ApplicationCommandOptionType.String || ApplicationCommandOptionType.Integer) &&
+                    option.choices
+                ) {
                     for (const choice of option.choices) {
                         const localizedChoice = localeOptionData.choices[choice.value];
                         if (!localizedChoice) {

--- a/src/common/localeUtil.ts
+++ b/src/common/localeUtil.ts
@@ -74,7 +74,7 @@ export function localizeCommand(command: Omit<SlashCommandBuilder, 'addSubcomman
     }
 
     // Localizing the command options...
-    if (jsonCommand.options) {
+    if (jsonCommand.options.length > 0) {
         assert(englishData.options, `Command /${command.name} must have option localizations.`);
         for (const unwritableOption of jsonCommand.options) {
             const option = unwritableOption as never as APIApplicationCommandOption;

--- a/src/common/localeUtil.ts
+++ b/src/common/localeUtil.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { APIApplicationCommandOption, Interaction, Locale, SlashCommandBuilder } from 'discord.js';
+import { APIApplicationCommandOption, BaseInteraction, Locale, SlashCommandBuilder } from 'discord.js';
 import { lstatSync, readdirSync } from 'fs';
 import i18n from 'i18next';
 import i18nextFsBackend, { FsBackendOptions } from 'i18next-fs-backend';
@@ -23,11 +23,11 @@ translatorInstance.use(i18nextFsBackend).init<FsBackendOptions>({
     }
 });
 
-export function useServerTranslator(interaction: Interaction) {
+export function useServerTranslator(interaction: BaseInteraction) {
     return translatorInstance.getFixedT(interaction.guildLocale ?? 'en');
 }
 
-export function useUserTranslator(interaction: Interaction) {
+export function useUserTranslator(interaction: BaseInteraction) {
     return translatorInstance.getFixedT(interaction.locale ?? 'en');
 }
 

--- a/src/common/localeUtil.ts
+++ b/src/common/localeUtil.ts
@@ -132,9 +132,11 @@ export function localizeCommand(command: Omit<SlashCommandBuilder, 'addSubcomman
                 if (localeOptionData.description) {
                     option.description_localizations[locale] = localeOptionData.description;
                 }
+
                 if (
                     localeOptionData.choices &&
-                    option.type === (ApplicationCommandOptionType.String || ApplicationCommandOptionType.Integer) &&
+                    (option.type === ApplicationCommandOptionType.String ||
+                        option.type === ApplicationCommandOptionType.Integer) &&
                     option.choices
                 ) {
                     for (const choice of option.choices) {

--- a/src/common/localeUtil.ts
+++ b/src/common/localeUtil.ts
@@ -42,7 +42,7 @@ export function useUserTranslator(interaction: BaseInteraction) {
 
 export const DISCORD_LOCALES = Object.values(Locale);
 
-type CommandMetadata = {
+export type CommandMetadata = {
     name?: string;
     description?: string;
     options?: Record<
@@ -79,7 +79,7 @@ export function localizeCommand(command: Omit<SlashCommandBuilder, 'addSubcomman
             jsonCommand.name_localizations[locale] = localeData.name;
         }
         if (localeData.description) {
-            jsonCommand.description_localizations[locale] = localeData.name;
+            jsonCommand.description_localizations[locale] = localeData.description;
         }
     }
 

--- a/src/common/localeUtil.ts
+++ b/src/common/localeUtil.ts
@@ -1,0 +1,106 @@
+import assert from 'assert';
+import { APIApplicationCommandOption, Interaction, Locale, SlashCommandBuilder } from 'discord.js';
+import { lstatSync, readdirSync } from 'fs';
+import i18n from 'i18next';
+import i18nextFsBackend, { FsBackendOptions } from 'i18next-fs-backend';
+import { join } from 'path';
+
+const translatorInstance = i18n.createInstance();
+const localeDir = join(__dirname, '..', '..', 'locales');
+translatorInstance.use(i18nextFsBackend).init<FsBackendOptions>({
+    initImmediate: false,
+    fallbackLng: 'en',
+    preload: readdirSync(localeDir).filter((fileName) => {
+        const joinedPath = join(localeDir, fileName);
+        const isDirectory = lstatSync(joinedPath).isDirectory();
+        return isDirectory;
+    }),
+    ns: 'bot',
+    defaultNS: 'bot',
+    backend: {
+        loadPath: join(localeDir, '{{lng}}', '{{ns}}.json'),
+        addPath: join(localeDir, '{{lng}}', '{{ns}}.missing.json')
+    }
+});
+
+export function useServerTranslator(interaction: Interaction) {
+    return translatorInstance.getFixedT(interaction.guildLocale ?? 'en');
+}
+
+export function useUserTranslator(interaction: Interaction) {
+    return translatorInstance.getFixedT(interaction.locale ?? 'en');
+}
+
+export const DISCORD_LOCALES = Object.values(Locale);
+
+type CommandMetadata = {
+    name?: string;
+    description?: string;
+    options?: Record<
+        string,
+        {
+            name?: string;
+            description?: string;
+        }
+    >;
+};
+
+type DeepMutable<T> = { -readonly [P in keyof T]: DeepMutable<T[P]> };
+export function localizeCommand(command: Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>) {
+    const jsonCommand = command as DeepMutable<typeof command>;
+
+    assert(jsonCommand.name, `Command /${command.name} must have a name using setName.`);
+    const metadataKey = `commands.${jsonCommand.name}.metadata`;
+    const englishData = translatorInstance.getResource('en', 'bot', metadataKey) as CommandMetadata | undefined;
+    assert(englishData, `Command /${command.name} must have English localization data.`);
+
+    // Localizing the top-level command...
+    jsonCommand.description = englishData.description ?? '!MISSING DESCRIPTION!';
+    /* eslint-disable camelcase */
+    jsonCommand.name_localizations = {};
+    /* eslint-disable camelcase */
+    jsonCommand.description_localizations = {};
+    for (const locale of DISCORD_LOCALES) {
+        const localeData = translatorInstance.getResource(locale, 'bot', metadataKey) as CommandMetadata | undefined;
+        if (locale.startsWith('en') || !localeData) {
+            continue;
+        }
+        if (localeData.name) {
+            jsonCommand.name_localizations[locale] = localeData.name;
+        }
+        if (localeData.description) {
+            jsonCommand.description_localizations[locale] = localeData.name;
+        }
+    }
+
+    // Localizing the command options...
+    if (jsonCommand.options) {
+        assert(englishData.options, `Command /${command.name} must have option localizations.`);
+        for (const unwritableOption of jsonCommand.options) {
+            const option = unwritableOption as never as APIApplicationCommandOption;
+            assert(option.name, `Option in /${command.name} must have a name using setName.`);
+
+            const englishOptionData = englishData.options[option.name];
+            option.description = englishOptionData.description ?? '!MISSING DESCRIPTION!';
+
+            option.name_localizations = {};
+            option.description_localizations = {};
+            for (const locale of DISCORD_LOCALES) {
+                const localeOptionData = (
+                    translatorInstance.getResource(locale, 'bot', metadataKey) as CommandMetadata | undefined
+                )?.options?.[option.name];
+                if (locale.startsWith('en') || !localeOptionData) {
+                    continue;
+                }
+                if (localeOptionData.name) {
+                    option.name_localizations[locale] = localeOptionData.name;
+                }
+                if (localeOptionData.description) {
+                    option.description_localizations[locale] = localeOptionData.description;
+                }
+            }
+        }
+    }
+
+    return jsonCommand as SlashCommandBuilder;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-// .ENV file is loaded automatically by dotenv
+// .ENV file is loaded auomaically by doenv
 import 'dotenv/config';
-
 // Only after loading .ENV file, we can load other modules
 import config from 'config';
 import { Client, Shard, ShardEvents, ShardingManager, ShardingManagerOptions } from 'discord.js';

--- a/src/interactions/autocomplete/play.ts
+++ b/src/interactions/autocomplete/play.ts
@@ -3,6 +3,8 @@ import { ApplicationCommandOptionChoiceData } from 'discord.js';
 import { BaseAutocompleteInteraction } from '../../classes/interactions';
 import { getTrackName, isQueryTooShort, shouldUseLastQuery } from '../../common/autocompleteUtils';
 import { BaseAutocompleteParams, BaseAutocompleteReturnType, RecentQuery } from '../../types/interactionTypes';
+import { TFunction } from 'i18next';
+import { useUserTranslator } from '../../common/localeUtil';
 
 class PlayAutocomplete extends BaseAutocompleteInteraction {
     private recentQueries = new Map<string, RecentQuery>();
@@ -14,6 +16,7 @@ class PlayAutocomplete extends BaseAutocompleteInteraction {
     async execute(params: BaseAutocompleteParams): BaseAutocompleteReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useUserTranslator(interaction);
 
         const query: string = interaction.options.getString('query', true);
 
@@ -29,8 +32,10 @@ class PlayAutocomplete extends BaseAutocompleteInteraction {
             return interaction.respond([]);
         }
 
-        const autocompleteChoices: ApplicationCommandOptionChoiceData<string>[] =
-            await this.getAutocompleteChoices(query);
+        const autocompleteChoices: ApplicationCommandOptionChoiceData<string>[] = await this.getAutocompleteChoices(
+            query,
+            translator
+        );
 
         if (!autocompleteChoices || autocompleteChoices.length === 0) {
             logger.debug(`Responding with empty results for query '${query}'`);
@@ -43,11 +48,14 @@ class PlayAutocomplete extends BaseAutocompleteInteraction {
         return interaction.respond(autocompleteChoices);
     }
 
-    private async getAutocompleteChoices(query: string): Promise<ApplicationCommandOptionChoiceData<string>[]> {
+    private async getAutocompleteChoices(
+        query: string,
+        translator: TFunction
+    ): Promise<ApplicationCommandOptionChoiceData<string>[]> {
         const player: Player = useMainPlayer()!;
         const searchResults: SearchResult = await player.search(query);
         return searchResults.tracks.slice(0, 5).map((track) => ({
-            name: getTrackName(track),
+            name: getTrackName(track, translator),
             value: track.url
         }));
     }

--- a/src/interactions/commands/info/help.ts
+++ b/src/interactions/commands/info/help.ts
@@ -15,7 +15,6 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
 import { ExtendedClient } from '../../../types/clientTypes';
-import { TFunction } from 'i18next';
 
 class HelpCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -37,7 +36,7 @@ class HelpCommand extends BaseSlashCommandInteraction {
                 .setURL(this.botOptions.serverInviteUrl)
                 .setStyle(ButtonStyle.Link)
                 .setEmoji(this.embedOptions.icons.support)
-                .setLabel('Support server')
+                .setLabel(translator('commands.help.supportServerButton'))
                 .toJSON();
             components.push(supportServerButton);
         }
@@ -47,7 +46,7 @@ class HelpCommand extends BaseSlashCommandInteraction {
                 .setURL(this.botOptions.botInviteUrl)
                 .setStyle(ButtonStyle.Link)
                 .setEmoji(this.embedOptions.icons.bot)
-                .setLabel('Add bot')
+                .setLabel(translator('commands.help.addBotButton'))
                 .toJSON();
             components.push(addBotButton);
         }
@@ -109,29 +108,6 @@ class HelpCommand extends BaseSlashCommandInteraction {
             return `**\`${option.name}\`** `;
         }
         return '';
-    }
-
-    private async getSupportServerString(translator: TFunction): Promise<string> {
-        if (!this.botOptions.serverInviteUrl) {
-            return '';
-        }
-
-        return translator('commands.help.supportServerCallout', {
-            icon: this.embedOptions.icons.support,
-            invite: this.botOptions.serverInviteUrl
-        });
-    }
-
-    private async getAddBotString(translator: TFunction): Promise<string> {
-        if (!this.botOptions.botInviteUrl) {
-            return '';
-        }
-
-        return translator('commands.help.addBotCallout', {
-            icon: this.embedOptions.icons.bot,
-            botName: this.botOptions.name,
-            invite: this.botOptions.botInviteUrl
-        });
     }
 }
 

--- a/src/interactions/commands/info/status.ts
+++ b/src/interactions/commands/info/status.ts
@@ -4,10 +4,11 @@ import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { getBotStatistics, getDiscordStatus, getPlayerStatistics, getSystemStatus } from '../../../common/statusUtils';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class StatusCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder().setName('status').setDescription('Show operational status of the bot.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('status'));
         super(data);
     }
 

--- a/src/interactions/commands/info/status.ts
+++ b/src/interactions/commands/info/status.ts
@@ -4,7 +4,7 @@ import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { getBotStatistics, getDiscordStatus, getPlayerStatistics, getSystemStatus } from '../../../common/statusUtils';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
 
 class StatusCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -15,31 +15,42 @@ class StatusCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction, client } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const [botStatisticsEmbedString, playerStatisticsEmbedString, systemStatusEmbedString] = await Promise.all([
-            getBotStatistics(client!, version),
-            getPlayerStatistics(client!),
-            getSystemStatus(executionId, false)
+            getBotStatistics(client!, version, translator),
+            getPlayerStatistics(client!, translator),
+            getSystemStatus(executionId, false, translator)
         ]);
-        const discordStatus = getDiscordStatus(client!);
+        const discordStatusEmbedString = getDiscordStatus(client!, translator);
 
         logger.debug('Responding with info embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setDescription(`**${this.embedOptions.icons.bot} Bot status**\n` + botStatisticsEmbedString)
+                    .setDescription(
+                        translator('statistics.botStatus.title', { icon: this.embedOptions.icons.bot }) +
+                            '\n' +
+                            botStatisticsEmbedString
+                    )
                     .addFields(
                         {
-                            name: `**${this.embedOptions.icons.queue} Queue status**`,
+                            name: translator('statistics.queueStatus.title', {
+                                icon: this.embedOptions.icons.queue
+                            }),
                             value: playerStatisticsEmbedString
                         },
                         {
-                            name: `**${this.embedOptions.icons.server} System status**`,
+                            name: translator('statistics.systemStatus.title', {
+                                icon: this.embedOptions.icons.server
+                            }),
                             value: systemStatusEmbedString
                         },
                         {
-                            name: `**${this.embedOptions.icons.discord} Discord status**`,
-                            value: discordStatus
+                            name: translator('statistics.discordStatus.title', {
+                                icon: this.embedOptions.icons.discord
+                            }),
+                            value: discordStatusEmbedString
                         }
                     )
                     .setColor(this.embedOptions.colors.info)

--- a/src/interactions/commands/player/back.ts
+++ b/src/interactions/commands/player/back.ts
@@ -5,7 +5,9 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkHistoryExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { TFunction } from 'i18next';
+import { formatSlashCommand } from '../../../common/formattingUtils';
 
 class BackCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -20,6 +22,7 @@ class BackCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const history: GuildQueueHistory = useHistory(interaction.guild!.id)!;
 
@@ -33,9 +36,9 @@ class BackCommand extends BaseSlashCommandInteraction {
         const backToTrackInput: number = interaction.options.getInteger('position')!;
 
         if (backToTrackInput) {
-            return await this.handleBackToTrackPosition(logger, interaction, history, backToTrackInput);
+            return await this.handleBackToTrackPosition(logger, interaction, history, backToTrackInput, translator);
         } else {
-            return await this.handleBackToPreviousTrack(logger, interaction, history);
+            return await this.handleBackToPreviousTrack(logger, interaction, history, translator);
         }
     }
 
@@ -43,20 +46,22 @@ class BackCommand extends BaseSlashCommandInteraction {
         logger: Logger,
         interaction: ChatInputCommandInteraction,
         history: GuildQueueHistory,
-        backtoTrackPosition: number
+        backtoTrackPosition: number,
+        translator: TFunction
     ) {
         if (backtoTrackPosition > history.tracks.data.length) {
             return await this.handleTrackPositionHigherThanQueueLength(
                 backtoTrackPosition,
                 history,
                 logger,
-                interaction
+                interaction,
+                translator
             );
         } else {
             await history.back();
             const recoveredTrack: Track = history.currentTrack! ?? history.tracks.data[backtoTrackPosition - 1];
             logger.debug('Went back to specified track position in history.');
-            return await this.respondWithSuccessEmbed(recoveredTrack, interaction);
+            return await this.respondWithSuccessEmbed(recoveredTrack, interaction, translator);
         }
     }
 
@@ -64,16 +69,20 @@ class BackCommand extends BaseSlashCommandInteraction {
         backToTrackPosition: number,
         history: GuildQueueHistory,
         logger: Logger,
-        interaction: ChatInputCommandInteraction
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
     ) {
         logger.debug('Specified track position was higher than total tracks.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\n` +
-                            `There are only **\`${history.tracks.data.length}\`** tracks in the history. You cannot go back to track **\`${backToTrackPosition}\`**.\n\n` +
-                            'View tracks added in the history with **`/history`**.'
+                        translator('commands.back.trackPositionHigherThanQueueLength', {
+                            icon: this.embedOptions.icons.warning,
+                            count: history.tracks.data.length,
+                            backPosition: backToTrackPosition,
+                            historyCommand: formatSlashCommand('history', translator)
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ]
@@ -83,40 +92,53 @@ class BackCommand extends BaseSlashCommandInteraction {
     private async handleBackToPreviousTrack(
         logger: Logger,
         interaction: ChatInputCommandInteraction,
-        history: GuildQueueHistory
+        history: GuildQueueHistory,
+        translator: TFunction
     ) {
         if (history.tracks.data.length === 0) {
-            return await this.handleNoTracksInHistory(logger, interaction);
+            return await this.handleNoTracksInHistory(logger, interaction, translator);
         }
 
         await history.back();
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
         const currentTrack: Track = queue.currentTrack!;
         logger.debug('Recovered track from history.');
-        return await this.respondWithSuccessEmbed(currentTrack, interaction);
+        return await this.respondWithSuccessEmbed(currentTrack, interaction, translator);
     }
-    private async handleNoTracksInHistory(logger: Logger, interaction: ChatInputCommandInteraction) {
+    private async handleNoTracksInHistory(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
+    ) {
         logger.debug('No tracks in history.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\n` +
-                            'The history is empty, add some tracks with **`/play`**!'
+                        translator('commands.back.trackHistoryEmpty', {
+                            icon: this.embedOptions.icons.warning,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ]
         });
     }
 
-    private async respondWithSuccessEmbed(recoveredTrack: Track, interaction: ChatInputCommandInteraction) {
+    private async respondWithSuccessEmbed(
+        recoveredTrack: Track,
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
+    ) {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.back} Recovered track**\n` +
-                            `${this.getDisplayTrackDurationAndUrl(recoveredTrack)}`
+                        translator('commands.back.trackRecovered', {
+                            icon: this.embedOptions.icons.back,
+                            track: this.getDisplayTrackDurationAndUrl(recoveredTrack)
+                        })
                     )
                     .setThumbnail(this.getTrackThumbnailUrl(recoveredTrack))
                     .setColor(this.embedOptions.colors.success)

--- a/src/interactions/commands/player/back.ts
+++ b/src/interactions/commands/player/back.ts
@@ -5,15 +5,15 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkHistoryExists, checkQueueCurrentTrack } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class BackCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('back')
-            .setDescription('Go back to previous track or specified position in history.')
-            .addIntegerOption((option) =>
-                option.setName('position').setDescription('The position in history to go back to.').setMinValue(1)
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('back')
+                .addIntegerOption((option) => option.setName('position').setMinValue(1))
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/back.ts
+++ b/src/interactions/commands/player/back.ts
@@ -50,7 +50,7 @@ class BackCommand extends BaseSlashCommandInteraction {
         translator: TFunction
     ) {
         if (backtoTrackPosition > history.tracks.data.length) {
-            return await this.handleTrackPositionHigherThanQueueLength(
+            return await this.handleTrackPositionHigherThanHistoryLength(
                 backtoTrackPosition,
                 history,
                 logger,
@@ -65,7 +65,7 @@ class BackCommand extends BaseSlashCommandInteraction {
         }
     }
 
-    private async handleTrackPositionHigherThanQueueLength(
+    private async handleTrackPositionHigherThanHistoryLength(
         backToTrackPosition: number,
         history: GuildQueueHistory,
         logger: Logger,
@@ -77,7 +77,7 @@ class BackCommand extends BaseSlashCommandInteraction {
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        translator('commands.back.trackPositionHigherThanQueueLength', {
+                        translator('commands.back.trackPositionHigherThanHistoryLength', {
                             icon: this.embedOptions.icons.warning,
                             count: history.tracks.data.length,
                             backPosition: backToTrackPosition,
@@ -137,7 +137,7 @@ class BackCommand extends BaseSlashCommandInteraction {
                     .setDescription(
                         translator('commands.back.trackRecovered', {
                             icon: this.embedOptions.icons.back,
-                            track: this.getDisplayTrackDurationAndUrl(recoveredTrack)
+                            track: this.getDisplayTrackDurationAndUrl(recoveredTrack, translator)
                         })
                     )
                     .setThumbnail(this.getTrackThumbnailUrl(recoveredTrack))

--- a/src/interactions/commands/player/filters.ts
+++ b/src/interactions/commands/player/filters.ts
@@ -26,6 +26,7 @@ import {
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 const ffmpegFilterOptions: FFmpegFilterOptions = config.get('ffmpegFilterOptions');
 const biquadFilterOptions: BiquadFilterOptions = config.get('biquadFilterOptions');
@@ -33,21 +34,21 @@ const equalizerFilterOptions: EqualizerFilterOptions = config.get('equalizerFilt
 
 class FiltersCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('filters')
-            .setDescription('Toggle various audio filters.')
-            .addStringOption((option) =>
-                option
-                    .setName('type')
-                    .setDescription('Audio filter type to use.')
-                    .setRequired(false)
-                    .addChoices(
-                        { name: 'FFmpeg', value: 'ffmpeg' },
-                        { name: 'Biquad', value: 'biquad' },
-                        { name: 'Equalizer', value: 'equalizer' },
-                        { name: 'Disable', value: 'disable' }
-                    )
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('filters')
+                .addStringOption((option) =>
+                    option
+                        .setName('type')
+                        .setRequired(false)
+                        .addChoices(
+                            { name: 'FFmpeg', value: 'ffmpeg' },
+                            { name: 'Biquad', value: 'biquad' },
+                            { name: 'Equalizer', value: 'equalizer' },
+                            { name: 'Disable', value: 'disable' }
+                        )
+                )
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/filters.ts
+++ b/src/interactions/commands/player/filters.ts
@@ -174,7 +174,11 @@ class FiltersCommand extends BaseSlashCommandInteraction {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setDescription(translator('commands.filters.toggleFilterInstructions'))
+                    .setDescription(
+                        translator('commands.filters.toggleFilterInstructions', {
+                            provider: filterProvider
+                        })
+                    )
                     .setColor(this.embedOptions.colors.info)
             ],
             components: actionRows

--- a/src/interactions/commands/player/filters.ts
+++ b/src/interactions/commands/player/filters.ts
@@ -35,7 +35,6 @@ const equalizerFilterOptions: EqualizerFilterOptions = config.get('equalizerFilt
 
 class FiltersCommand extends BaseSlashCommandInteraction {
     constructor() {
-        // TODO: Localize choices
         // TODO: Implement system for localized filter names and descriptions
         const data = localizeCommand(
             new SlashCommandBuilder()
@@ -45,10 +44,10 @@ class FiltersCommand extends BaseSlashCommandInteraction {
                         .setName('type')
                         .setRequired(false)
                         .addChoices(
-                            { name: 'FFmpeg', value: 'ffmpeg' },
-                            { name: 'Biquad', value: 'biquad' },
-                            { name: 'Equalizer', value: 'equalizer' },
-                            { name: 'Disable', value: 'disable' }
+                            { value: 'ffmpeg', name: ' ' },
+                            { value: 'biquad', name: ' ' },
+                            { value: 'equalizer', name: ' ' },
+                            { value: 'disable', name: ' ' }
                         )
                 )
         );

--- a/src/interactions/commands/player/history.ts
+++ b/src/interactions/commands/player/history.ts
@@ -16,15 +16,15 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkHistoryExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class HistoryCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('history')
-            .setDescription('Show history of tracks that have been played.')
-            .addIntegerOption((option) =>
-                option.setName('page').setDescription('Page number to display for the history').setMinValue(1)
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('history')
+                .addIntegerOption((option) => option.setName('page').setMinValue(1))
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/history.ts
+++ b/src/interactions/commands/player/history.ts
@@ -18,7 +18,7 @@ import { checkHistoryExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
 import { TFunction } from 'i18next';
-import { formatSlashCommand } from '../../../common/formattingUtils';
+import { formatRepeatModeDetailed, formatSlashCommand } from '../../../common/formattingUtils';
 
 class HistoryCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -130,24 +130,18 @@ class HistoryCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedQueueAuthor(interaction, queue, translator))
                     .setDescription(
-                        translator('musicPlayerCommon.nowPlayingTitle', {
+                        `${translator('musicPlayerCommon.nowPlayingTitle', {
                             icon: this.embedOptions.icons.audioPlaying
-                        }) +
-                            '\n' +
-                            this.getFormattedTrackUrl(currentTrack, translator) +
-                            '\n' +
-                            translator('musicPlayerCommon.requestedBy', {
+                        })}\n` +
+                            `${this.getFormattedTrackUrl(currentTrack, translator)}\n` +
+                            `${translator('musicPlayerCommon.requestedBy', {
                                 user: this.getDisplayTrackRequestedBy(currentTrack, translator)
-                            }) +
-                            '\n' +
-                            this.getDisplayQueueProgressBar(queue, translator) +
-                            '\n' +
-                            '\n' +
-                            this.getDisplayRepeatMode(queue.repeatMode, translator) +
-                            translator('commands.history.tracksInHistoryTitle', {
+                            })}\n` +
+                            `${this.getDisplayQueueProgressBar(queue, translator)}\n\n` +
+                            `${formatRepeatModeDetailed(queue.repeatMode, this.embedOptions, translator)}\n` +
+                            `${translator('commands.history.tracksInHistoryTitle', {
                                 icon: this.embedOptions.icons.queue
-                            }) +
-                            '\n' +
+                            })}\n` +
                             historyTracksListString
                     )
                     .setThumbnail(this.getTrackThumbnailUrl(currentTrack))

--- a/src/interactions/commands/player/history.ts
+++ b/src/interactions/commands/player/history.ts
@@ -130,14 +130,13 @@ class HistoryCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedQueueAuthor(interaction, queue, translator))
                     .setDescription(
-                        `${translator('musicPlayerCommon.nowPlayingTitle', {
-                            icon: this.embedOptions.icons.audioPlaying
-                        })}\n` +
+                        this.getDisplayTrackPlayingStatus(queue, translator) +
+                            '\n' +
                             `${this.getFormattedTrackUrl(currentTrack, translator)}\n` +
                             `${translator('musicPlayerCommon.requestedBy', {
                                 user: this.getDisplayTrackRequestedBy(currentTrack, translator)
                             })}\n` +
-                            `${this.getDisplayQueueProgressBar(queue, translator)}\n\n` +
+                            `${this.getDisplayQueueProgressBar(queue, translator)}\n` +
                             `${formatRepeatModeDetailed(queue.repeatMode, this.embedOptions, translator)}\n` +
                             `${translator('commands.history.tracksInHistoryTitle', {
                                 icon: this.embedOptions.icons.queue
@@ -152,6 +151,12 @@ class HistoryCommand extends BaseSlashCommandInteraction {
         });
         return Promise.resolve();
     }
+
+    private getDisplayTrackPlayingStatus = (queue: GuildQueue, translator: TFunction): string => {
+        return queue.node.isPaused()
+            ? translator('musicPlayerCommon.nowPausedTitle', { icon: this.embedOptions.icons.paused })
+            : translator('musicPlayerCommon.nowPlayingTitle', { icon: this.embedOptions.icons.audioPlaying });
+    };
 
     private async handleNoCurrentTrack(
         logger: Logger,

--- a/src/interactions/commands/player/join.ts
+++ b/src/interactions/commands/player/join.ts
@@ -5,12 +5,11 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkInVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { checkVoicePermissionJoinAndTalk } from '../../../utils/validation/permissionValidator';
 import { Logger } from 'pino';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class JoinCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('join')
-            .setDescription('The bot will join the voice channel if not already in one.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('join'));
         super(data);
     }
 

--- a/src/interactions/commands/player/leave.ts
+++ b/src/interactions/commands/player/leave.ts
@@ -4,12 +4,11 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class LeaveCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('leave')
-            .setDescription('Clear the queue and remove bot from voice channel.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('leave'));
         super(data);
     }
 

--- a/src/interactions/commands/player/leave.ts
+++ b/src/interactions/commands/player/leave.ts
@@ -4,7 +4,8 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { formatSlashCommand } from '../../../common/formattingUtils';
 
 class LeaveCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -15,6 +16,7 @@ class LeaveCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -33,9 +35,10 @@ class LeaveCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.success} Leaving channel**\n` +
-                            'Cleared the track queue and left voice channel.\n\n' +
-                            'To play more music, use the **`/play`** command!'
+                        translator('commands.leave.leavingChannel', {
+                            icon: this.embedOptions.icons.success,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(this.embedOptions.colors.success)
             ]

--- a/src/interactions/commands/player/loop.ts
+++ b/src/interactions/commands/player/loop.ts
@@ -11,7 +11,8 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { TFunction } from 'i18next';
 
 class LoopCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -37,6 +38,7 @@ class LoopCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -50,34 +52,44 @@ class LoopCommand extends BaseSlashCommandInteraction {
         const currentRepeatMode: QueueRepeatMode = queue.repeatMode;
 
         if (!userInputRepeatMode && userInputRepeatMode !== 0) {
-            return await this.handleNoInputMode(logger, interaction, currentRepeatMode);
+            return await this.handleNoInputMode(logger, interaction, currentRepeatMode, translator);
         }
 
         if (userInputRepeatMode === currentRepeatMode) {
-            return await this.handleSameMode(logger, interaction, userInputRepeatMode);
+            return await this.handleSameMode(logger, interaction, userInputRepeatMode, translator);
         }
 
-        return await this.handleChangeMode(logger, interaction, queue, currentRepeatMode, userInputRepeatMode);
+        return await this.handleChangeMode(
+            logger,
+            interaction,
+            queue,
+            currentRepeatMode,
+            userInputRepeatMode,
+            translator
+        );
     }
 
     private async handleNoInputMode(
         logger: Logger,
         interaction: ChatInputCommandInteraction,
-        currentRepeatMode: QueueRepeatMode
+        currentRepeatMode: QueueRepeatMode,
+        translator: TFunction
     ): Promise<Message> {
         logger.debug('No repeat mode was provided, responding with current repeat mode.');
 
         const repeatModeEmbedIcon =
             currentRepeatMode === 3 ? this.embedOptions.icons.autoplay : this.embedOptions.icons.loop;
-        const repeatModeEmbedName = this.getRepeatModeEmbedName(currentRepeatMode);
+        const repeatModeEmbedName = this.getRepeatModeEmbedName(currentRepeatMode, translator);
 
         logger.debug('Responding with info embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${repeatModeEmbedIcon} Current loop mode**\n` +
-                            `The looping mode is currently set to **\`${repeatModeEmbedName}\`**.`
+                        translator('commands.loop.loopModeInformation', {
+                            icon: repeatModeEmbedIcon,
+                            mode: repeatModeEmbedName
+                        })
                     )
                     .setColor(this.embedOptions.colors.info)
             ]
@@ -87,17 +99,20 @@ class LoopCommand extends BaseSlashCommandInteraction {
     private async handleSameMode(
         logger: Logger,
         interaction: ChatInputCommandInteraction,
-        currentRepeatMode: QueueRepeatMode
+        currentRepeatMode: QueueRepeatMode,
+        translator: TFunction
     ): Promise<Message> {
-        const repeatModeEmbedName = this.getRepeatModeEmbedName(currentRepeatMode);
+        const repeatModeEmbedName = this.getRepeatModeEmbedName(currentRepeatMode, translator);
         logger.debug(`Loop mode is already set to '${repeatModeEmbedName}'.`);
         logger.debug('Responding with warning embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\n` +
-                            `Loop mode is already **\`${repeatModeEmbedName}\`**.`
+                        translator('commands.loop.alreadySet', {
+                            icon: this.embedOptions.icons.warning,
+                            mode: repeatModeEmbedName
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ]
@@ -109,10 +124,15 @@ class LoopCommand extends BaseSlashCommandInteraction {
         interaction: ChatInputCommandInteraction,
         queue: GuildQueue,
         fromRepeatMode: QueueRepeatMode,
-        toRepeatMode: QueueRepeatMode
+        toRepeatMode: QueueRepeatMode,
+        translator: TFunction
     ): Promise<Message> {
-        const newRepeatModeEmbedName = this.getRepeatModeEmbedName(toRepeatMode);
-        const getChangedRepeatModeEmbedReply = this.getChangedRepeatModeEmbedReply(fromRepeatMode, toRepeatMode);
+        const newRepeatModeEmbedName = this.getRepeatModeEmbedName(toRepeatMode, translator);
+        const getChangedRepeatModeEmbedReply = this.getChangedRepeatModeEmbedReply(
+            fromRepeatMode,
+            toRepeatMode,
+            translator
+        );
 
         queue.setRepeatMode(toRepeatMode);
         logger.debug(`Loop mode changed to '${newRepeatModeEmbedName}'.`);
@@ -128,35 +148,48 @@ class LoopCommand extends BaseSlashCommandInteraction {
         });
     }
 
-    private getRepeatModeEmbedName(repeatMode: QueueRepeatMode): string {
+    private getRepeatModeEmbedName(repeatMode: QueueRepeatMode, translator: TFunction): string {
         const repeatModeEmbedString: { [key in QueueRepeatMode]: string } = {
-            [QueueRepeatMode.OFF]: 'disabled',
-            [QueueRepeatMode.TRACK]: 'track',
-            [QueueRepeatMode.QUEUE]: 'queue',
-            [QueueRepeatMode.AUTOPLAY]: 'autoplay'
+            [QueueRepeatMode.OFF]: translator('commands.loop.repeatMode.off'),
+            [QueueRepeatMode.TRACK]: translator('commands.loop.repeatMode.track'),
+            [QueueRepeatMode.QUEUE]: translator('commands.loop.repeatMode.queue'),
+            [QueueRepeatMode.AUTOPLAY]: translator('commands.loop.repeatMode.autoplay')
         };
 
         return repeatModeEmbedString[repeatMode];
     }
 
-    private getChangedRepeatModeEmbedReply(fromRepeatMode: QueueRepeatMode, toRepeatMode: QueueRepeatMode): string {
-        const fromRepeatModeEmbedName = this.getRepeatModeEmbedName(fromRepeatMode);
-        const toRepeatModeEmbedName = this.getRepeatModeEmbedName(toRepeatMode);
+    private getChangedRepeatModeEmbedReply(
+        fromRepeatMode: QueueRepeatMode,
+        toRepeatMode: QueueRepeatMode,
+        translator: TFunction
+    ): string {
+        const fromRepeatModeEmbedName = this.getRepeatModeEmbedName(fromRepeatMode, translator);
+        const toRepeatModeEmbedName = this.getRepeatModeEmbedName(toRepeatMode, translator);
 
         let repeatModeIcon = this.embedOptions.icons.looping;
-        let newRepeatModeMessage = `The ${toRepeatModeEmbedName} will now play on repeat!`;
+        let newRepeatModeMessage: string = translator('commands.loop.willNowPlay', {
+            mode: toRepeatModeEmbedName
+        });
 
         if (toRepeatMode === QueueRepeatMode.OFF) {
             repeatModeIcon = this.embedOptions.icons.success;
-            newRepeatModeMessage = `The ${fromRepeatModeEmbedName} will no longer play on repeat!`;
+            newRepeatModeMessage = translator('commands.loop.willNoLongerPlay', {
+                mode: fromRepeatModeEmbedName
+            });
         } else if (toRepeatMode === QueueRepeatMode.AUTOPLAY) {
             repeatModeIcon = this.embedOptions.icons.autoplaying;
-            newRepeatModeMessage = 'When the queue is empty, similar tracks will start playing!';
+            newRepeatModeMessage = translator('commands.loop.willAutoplay');
         }
 
         return (
-            `**${repeatModeIcon} Loop mode changed**\n` +
-            `Changing loop mode from **\`${fromRepeatModeEmbedName}\`** to **\`${toRepeatModeEmbedName}\`**.\n\n` +
+            translator('commands.loop.modeChanged', {
+                icon: repeatModeIcon,
+                fromName: fromRepeatModeEmbedName,
+                toName: toRepeatModeEmbedName
+            }) +
+            '\n' +
+            '\n' +
             newRepeatModeMessage
         );
     }

--- a/src/interactions/commands/player/loop.ts
+++ b/src/interactions/commands/player/loop.ts
@@ -11,24 +11,26 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class LoopCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('loop')
-            .setDescription('Toggle looping a track, the whole queue or autoplay.')
-            .addIntegerOption(() =>
-                new SlashCommandIntegerOption()
-                    .setName('mode')
-                    .setDescription('Loop mode: Track, queue, autoplay or disabled.')
-                    .setRequired(false)
-                    .addChoices(
-                        { name: 'Track', value: QueueRepeatMode.TRACK },
-                        { name: 'Queue', value: QueueRepeatMode.QUEUE },
-                        { name: 'Autoplay', value: QueueRepeatMode.AUTOPLAY },
-                        { name: 'Disabled', value: QueueRepeatMode.OFF }
-                    )
-            );
+        // TODO: Add choice localization support
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('loop')
+                .addIntegerOption(() =>
+                    new SlashCommandIntegerOption()
+                        .setName('mode')
+                        .setRequired(false)
+                        .addChoices(
+                            { name: 'Track', value: QueueRepeatMode.TRACK },
+                            { name: 'Queue', value: QueueRepeatMode.QUEUE },
+                            { name: 'Autoplay', value: QueueRepeatMode.AUTOPLAY },
+                            { name: 'Disabled', value: QueueRepeatMode.OFF }
+                        )
+                )
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/loop.ts
+++ b/src/interactions/commands/player/loop.ts
@@ -13,10 +13,10 @@ import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
 import { TFunction } from 'i18next';
+import { formatRepeatMode } from '../../../common/formattingUtils';
 
 class LoopCommand extends BaseSlashCommandInteraction {
     constructor() {
-        // TODO: Add choice localization support
         const data = localizeCommand(
             new SlashCommandBuilder()
                 .setName('loop')
@@ -25,10 +25,10 @@ class LoopCommand extends BaseSlashCommandInteraction {
                         .setName('mode')
                         .setRequired(false)
                         .addChoices(
-                            { name: 'Track', value: QueueRepeatMode.TRACK },
-                            { name: 'Queue', value: QueueRepeatMode.QUEUE },
-                            { name: 'Autoplay', value: QueueRepeatMode.AUTOPLAY },
-                            { name: 'Disabled', value: QueueRepeatMode.OFF }
+                            { value: QueueRepeatMode.TRACK, name: ' ' },
+                            { value: QueueRepeatMode.QUEUE, name: ' ' },
+                            { value: QueueRepeatMode.AUTOPLAY, name: ' ' },
+                            { value: QueueRepeatMode.OFF, name: ' ' }
                         )
                 )
         );
@@ -79,7 +79,7 @@ class LoopCommand extends BaseSlashCommandInteraction {
 
         const repeatModeEmbedIcon =
             currentRepeatMode === 3 ? this.embedOptions.icons.autoplay : this.embedOptions.icons.loop;
-        const repeatModeEmbedName = this.getRepeatModeEmbedName(currentRepeatMode, translator);
+        const repeatModeEmbedName = formatRepeatMode(currentRepeatMode, translator);
 
         logger.debug('Responding with info embed.');
         return await interaction.editReply({
@@ -102,7 +102,7 @@ class LoopCommand extends BaseSlashCommandInteraction {
         currentRepeatMode: QueueRepeatMode,
         translator: TFunction
     ): Promise<Message> {
-        const repeatModeEmbedName = this.getRepeatModeEmbedName(currentRepeatMode, translator);
+        const repeatModeEmbedName = formatRepeatMode(currentRepeatMode, translator);
         logger.debug(`Loop mode is already set to '${repeatModeEmbedName}'.`);
         logger.debug('Responding with warning embed.');
         return await interaction.editReply({
@@ -127,7 +127,7 @@ class LoopCommand extends BaseSlashCommandInteraction {
         toRepeatMode: QueueRepeatMode,
         translator: TFunction
     ): Promise<Message> {
-        const newRepeatModeEmbedName = this.getRepeatModeEmbedName(toRepeatMode, translator);
+        const newRepeatModeEmbedName = formatRepeatMode(toRepeatMode, translator);
         const getChangedRepeatModeEmbedReply = this.getChangedRepeatModeEmbedReply(
             fromRepeatMode,
             toRepeatMode,
@@ -148,24 +148,13 @@ class LoopCommand extends BaseSlashCommandInteraction {
         });
     }
 
-    private getRepeatModeEmbedName(repeatMode: QueueRepeatMode, translator: TFunction): string {
-        const repeatModeEmbedString: { [key in QueueRepeatMode]: string } = {
-            [QueueRepeatMode.OFF]: translator('commands.loop.repeatMode.off'),
-            [QueueRepeatMode.TRACK]: translator('commands.loop.repeatMode.track'),
-            [QueueRepeatMode.QUEUE]: translator('commands.loop.repeatMode.queue'),
-            [QueueRepeatMode.AUTOPLAY]: translator('commands.loop.repeatMode.autoplay')
-        };
-
-        return repeatModeEmbedString[repeatMode];
-    }
-
     private getChangedRepeatModeEmbedReply(
         fromRepeatMode: QueueRepeatMode,
         toRepeatMode: QueueRepeatMode,
         translator: TFunction
     ): string {
-        const fromRepeatModeEmbedName = this.getRepeatModeEmbedName(fromRepeatMode, translator);
-        const toRepeatModeEmbedName = this.getRepeatModeEmbedName(toRepeatMode, translator);
+        const fromRepeatModeEmbedName = formatRepeatMode(fromRepeatMode, translator);
+        const toRepeatModeEmbedName = formatRepeatMode(toRepeatMode, translator);
 
         let repeatModeIcon = this.embedOptions.icons.looping;
         let newRepeatModeMessage: string = translator('commands.loop.willNowPlay', {

--- a/src/interactions/commands/player/lyrics.ts
+++ b/src/interactions/commands/player/lyrics.ts
@@ -13,15 +13,8 @@ class LyricsCommand extends BaseSlashCommandInteraction {
         const data = localizeCommand(
             new SlashCommandBuilder()
                 .setName('lyrics')
-                // .setDescription('Search Genius lyrics for current or specified track.')
                 .addStringOption((option) =>
-                    option
-                        .setName('query')
-                        // .setDescription('Search query by text or URL.')
-                        .setRequired(false)
-                        .setMinLength(2)
-                        .setMaxLength(500)
-                        .setAutocomplete(true)
+                    option.setName('query').setRequired(false).setMinLength(2).setMaxLength(500).setAutocomplete(true)
                 )
         );
         super(data);

--- a/src/interactions/commands/player/lyrics.ts
+++ b/src/interactions/commands/player/lyrics.ts
@@ -6,21 +6,24 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class LyricsCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('lyrics')
-            .setDescription('Search Genius lyrics for current or specified track.')
-            .addStringOption((option) =>
-                option
-                    .setName('query')
-                    .setDescription('Search query by text or URL.')
-                    .setRequired(false)
-                    .setMinLength(2)
-                    .setMaxLength(500)
-                    .setAutocomplete(true)
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('lyrics')
+                // .setDescription('Search Genius lyrics for current or specified track.')
+                .addStringOption((option) =>
+                    option
+                        .setName('query')
+                        // .setDescription('Search query by text or URL.')
+                        .setRequired(false)
+                        .setMinLength(2)
+                        .setMaxLength(500)
+                        .setAutocomplete(true)
+                )
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/lyrics.ts
+++ b/src/interactions/commands/player/lyrics.ts
@@ -6,7 +6,8 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { TFunction } from 'i18next';
 
 class LyricsCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -23,6 +24,7 @@ class LyricsCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
         const query: string = interaction.options.getString('query')!;
@@ -50,14 +52,14 @@ class LyricsCommand extends BaseSlashCommandInteraction {
 
         if (!finalLyricsData) {
             logger.debug('No matching lyrics found.');
-            return await this.sendNoLyricsFoundEmbed(logger, interaction, geniusSearchQuery);
+            return await this.sendNoLyricsFoundEmbed(logger, interaction, geniusSearchQuery, translator);
         }
 
         if (finalLyricsData.lyrics.length > 3800) {
-            return await this.sendMultipleLyricsMessages(logger, interaction, finalLyricsData);
+            return await this.sendMultipleLyricsMessages(logger, interaction, finalLyricsData, translator);
         }
 
-        return await this.sendLyricsEmbed(logger, interaction, finalLyricsData);
+        return await this.sendLyricsEmbed(logger, interaction, finalLyricsData, translator);
     }
 
     private getGeniusSearchQuery(logger: Logger, query: string, queue: GuildQueue): string {
@@ -155,15 +157,18 @@ class LyricsCommand extends BaseSlashCommandInteraction {
     private async sendNoLyricsFoundEmbed(
         logger: Logger,
         interaction: ChatInputCommandInteraction,
-        geniusSearchQuery: string
+        geniusSearchQuery: string,
+        translator: TFunction
     ) {
         logger.debug('Responding with warning embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} No lyrics found**\n` +
-                            `There was no Genius lyrics found for track **${geniusSearchQuery}**.`
+                        translator('commands.lyrics.noLyricsFound', {
+                            icon: this.embedOptions.icons.warning,
+                            query: geniusSearchQuery
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ]
@@ -173,7 +178,8 @@ class LyricsCommand extends BaseSlashCommandInteraction {
     private async sendMultipleLyricsMessages(
         logger: Logger,
         interaction: ChatInputCommandInteraction,
-        geniusLyricsResult: LyricsData
+        geniusLyricsResult: LyricsData,
+        translator: TFunction
     ): Promise<Message> {
         logger.debug('Lyrics text too long, splitting into multiple messages.');
         const messageCount: number = Math.ceil(geniusLyricsResult.lyrics.length / 3800);
@@ -181,9 +187,13 @@ class LyricsCommand extends BaseSlashCommandInteraction {
         embedList.push(
             new EmbedBuilder()
                 .setDescription(
-                    `**${this.embedOptions.icons.queue} Showing lyrics**\n` +
-                        `**Track: [${geniusLyricsResult.title}](${geniusLyricsResult.url})**\n` +
-                        `**Artist: [${geniusLyricsResult.artist.name}](${geniusLyricsResult.artist.url})**\n\n`
+                    translator('commands.lyrics.lyricsEmbed', {
+                        icon: this.embedOptions.icons.queue,
+                        trackTitle: geniusLyricsResult.title,
+                        trackUrl: geniusLyricsResult.url,
+                        artistName: geniusLyricsResult.artist.name,
+                        artistUrl: geniusLyricsResult.artist.url
+                    })
                 )
                 .setColor(this.embedOptions.colors.info)
         );
@@ -204,16 +214,23 @@ class LyricsCommand extends BaseSlashCommandInteraction {
     private async sendLyricsEmbed(
         logger: Logger,
         interaction: ChatInputCommandInteraction,
-        geniusLyricsResult: LyricsData
+        geniusLyricsResult: LyricsData,
+        translator: TFunction
     ): Promise<Message> {
         logger.debug('Responding with info embed.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.queue} Showing lyrics**\n` +
-                            `**Track: [${geniusLyricsResult.title}](${geniusLyricsResult.url})**\n` +
-                            `**Artist: [${geniusLyricsResult.artist.name}](${geniusLyricsResult.artist.url})**\n\n` +
+                        translator('commands.lyrics.lyricsEmbed', {
+                            icon: this.embedOptions.icons.queue,
+                            trackTitle: geniusLyricsResult.title,
+                            trackUrl: geniusLyricsResult.url,
+                            artistName: geniusLyricsResult.artist.name,
+                            artistUrl: geniusLyricsResult.artist.url
+                        }) +
+                            '\n' +
+                            '\n' +
                             `\`\`\`fix\n${geniusLyricsResult.lyrics}\`\`\``
                     )
                     .setColor(this.embedOptions.colors.info)

--- a/src/interactions/commands/player/move.ts
+++ b/src/interactions/commands/player/move.ts
@@ -5,26 +5,16 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class MoveCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('move')
-            .setDescription('Move a track to a specified position in queue.')
-            .addIntegerOption((option) =>
-                option
-                    .setName('from')
-                    .setDescription('The position of the track to move')
-                    .setMinValue(1)
-                    .setRequired(true)
-            )
-            .addIntegerOption((option) =>
-                option
-                    .setName('to')
-                    .setDescription('The position to move the track to')
-                    .setMinValue(1)
-                    .setRequired(true)
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('move')
+                .addIntegerOption((option) => option.setName('from').setMinValue(1).setRequired(true))
+                .addIntegerOption((option) => option.setName('to').setMinValue(1).setRequired(true))
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/nowplaying.ts
+++ b/src/interactions/commands/player/nowplaying.ts
@@ -14,12 +14,11 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType, TrackMetadata } from '../../../types/interactionTypes';
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class NowPlayingCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('nowplaying')
-            .setDescription('Show information about the current track.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('nowplaying'));
         super(data);
     }
 

--- a/src/interactions/commands/player/nowplaying.ts
+++ b/src/interactions/commands/player/nowplaying.ts
@@ -98,7 +98,7 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
                             `${translator('musicPlayerCommon.requestedBy', {
                                 user: displayTrackRequestedBy
                             })}\n` +
-                            `${displayEmbedProgressBar}\n\n ` +
+                            `${displayEmbedProgressBar}\n` +
                             `${displayQueueRepeatMode}\n\n`
                     )
                     .addFields(this.getEmbedFields(currentTrack, translator))

--- a/src/interactions/commands/player/nowplaying.ts
+++ b/src/interactions/commands/player/nowplaying.ts
@@ -15,6 +15,8 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType, TrackMetadata } fro
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { TFunction } from 'i18next';
+import { formatRepeatModeDetailed } from '../../../common/formattingUtils';
 
 class NowPlayingCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -40,8 +42,12 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
         const currentTrack: Track = queue.currentTrack!;
         const displayTrackUrl: string = this.getFormattedTrackUrl(currentTrack, translator);
         const displayTrackRequestedBy: string = this.getDisplayTrackRequestedBy(currentTrack, translator);
-        const displayTrackPlayingStatus: string = this.getDisplayTrackPlayingStatus(queue);
-        const displayQueueRepeatMode: string = this.getDisplayQueueRepeatMode(queue);
+        const displayTrackPlayingStatus: string = this.getDisplayTrackPlayingStatus(queue, translator);
+        const displayQueueRepeatMode: string = formatRepeatModeDetailed(
+            queue.repeatMode,
+            this.embedOptions,
+            translator
+        );
         const displayEmbedProgressBar: string = this.getDisplayQueueProgressBar(queue, translator);
 
         const components: APIMessageActionRowComponent[] = [];
@@ -69,9 +75,11 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
         components.push(skipButton);
 
         if (this.embedOptions.components.showButtonLabels) {
-            previousButton.label = 'Previous';
-            playPauseButton.label = queue.node.isPaused() ? 'Resume' : 'Pause';
-            skipButton.label = 'Skip';
+            previousButton.label = translator('musicPlayerCommon.controls.previous');
+            playPauseButton.label = queue.node.isPaused()
+                ? translator('musicPlayerCommon.controls.resume')
+                : translator('musicPlayerCommon.controls.pause');
+            skipButton.label = translator('musicPlayerCommon.controls.skip');
         }
 
         const embedActionRow: APIActionRowComponent<APIMessageActionRowComponent> = {
@@ -87,13 +95,17 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
                     .setDescription(
                         `${displayTrackPlayingStatus}\n` +
                             `${displayTrackUrl}\n` +
-                            `**Requested by:** ${displayTrackRequestedBy}\n` +
+                            `${translator('musicPlayerCommon.requestedBy', {
+                                user: displayTrackRequestedBy
+                            })}\n` +
                             `${displayEmbedProgressBar}\n\n ` +
                             `${displayQueueRepeatMode}\n\n`
                     )
-                    .addFields(this.getEmbedFields(currentTrack))
+                    .addFields(this.getEmbedFields(currentTrack, translator))
                     .setFooter({
-                        text: tracksInQueueCount ? `${tracksInQueueCount} other tracks in the queue...` : ' '
+                        text: tracksInQueueCount
+                            ? translator('commands.nowplaying.otherTracksInQueue', { count: tracksInQueueCount })
+                            : ' '
                     })
                     .setThumbnail(this.getTrackThumbnailUrl(queue.currentTrack!))
                     .setColor(this.embedOptions.colors.info)
@@ -102,37 +114,34 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
         });
     }
 
-    private getDisplayPlays(currentTrack: Track | undefined): string {
+    private getDisplayPlays(currentTrack: Track | undefined, translator: TFunction): string {
         const trackMetadata = currentTrack?.metadata as TrackMetadata;
 
-        let displayPlays: string =
-            (currentTrack?.views || trackMetadata?.bridge?.views || 0).toLocaleString('en-US') ?? '0';
-
-        if (displayPlays === '0') {
-            displayPlays = 'Unavailable';
-        }
-
-        return displayPlays;
+        return translator('commands.nowplaying.playCount', {
+            count: currentTrack?.views || trackMetadata?.bridge?.views || 0
+        });
     }
 
-    private getDisplayTrackAuthor(currentTrack: Track | undefined): string {
-        let author: string = currentTrack?.author ? currentTrack.author : 'Unavailable';
-        if (author === 'cdn.discordapp.com') {
-            author = 'Unavailable';
+    private getDisplayTrackAuthor(currentTrack: Track | undefined, translator: TFunction): string {
+        let author = currentTrack?.author;
+        if (!author || author === 'cdn.discordapp.com') {
+            author = translator('musicPlayerCommon.unavailableAuthor');
         }
         return author;
     }
 
-    private getTrackSourceString(currentTrack: Track): string {
+    private getTrackSourceString(currentTrack: Track, translator: TFunction): string {
         const sourceStringsFormatted: Map<string, string> = new Map([
             ['youtube', 'YouTube'],
             ['soundcloud', 'SoundCloud'],
             ['spotify', 'Spotify'],
             ['apple_music', 'Apple Music'],
-            ['arbitrary', 'Direct source']
+            ['arbitrary', translator('commands.pause.directSource')]
         ]);
 
-        return sourceStringsFormatted.get(currentTrack.raw.source!) ?? 'Unavailable';
+        return (
+            sourceStringsFormatted.get(currentTrack.raw.source!) ?? translator('musicPlayerCommon.unavailableSource')
+        );
     }
 
     private getTrackSourceIcon(currentTrack: Track): string {
@@ -147,59 +156,38 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
         return sourceIcons.get(currentTrack.raw.source!) ?? '';
     }
 
-    private getDisplayTrackSource(currentTrack: Track) {
-        const trackSource: string = this.getTrackSourceString(currentTrack) ?? 'Unavailable';
+    private getDisplayTrackSource(currentTrack: Track, translator: TFunction) {
+        const trackSource: string = this.getTrackSourceString(currentTrack, translator);
         const trackSourceIcon: string = this.getTrackSourceIcon(currentTrack) ?? '';
 
         return `**${trackSourceIcon} [${trackSource}](${currentTrack.raw.url ?? currentTrack.url})**`;
     }
 
-    private getRepeatModeString(repeatMode: number): string {
-        const loopModesFormatted: Map<number, string> = new Map([
-            [0, 'disabled'],
-            [1, 'track'],
-            [2, 'queue'],
-            [3, 'autoplay']
-        ]);
-
-        return loopModesFormatted.get(repeatMode)!;
-    }
-
-    private getDisplayQueueRepeatMode = (queue: GuildQueue): string => {
-        const repeatMode: number = queue.repeatMode;
-        if (repeatMode === 0) {
-            return '';
-        }
-
-        const loopModeUserString: string = this.getRepeatModeString(repeatMode);
-        const icon = repeatMode === 3 ? this.embedOptions.icons.autoplay : this.embedOptions.icons.loop;
-        return (
-            `**${icon} Looping**\n` +
-            `Loop mode is set to **\`${loopModeUserString}\`**. You can change it with **\`/loop\`**.`
-        );
-    };
-
-    private getDisplayTrackPlayingStatus = (queue: GuildQueue): string => {
+    private getDisplayTrackPlayingStatus = (queue: GuildQueue, translator: TFunction): string => {
         return queue.node.isPaused()
-            ? '**Currently Paused**'
-            : `**${this.embedOptions.icons.audioPlaying} Now Playing**`;
+            ? translator('musicPlayerCommon.nowPausedTitle', {
+                  icon: this.embedOptions.icons.paused
+              })
+            : translator('musicPlayerCommon.nowPlayingTitle', {
+                  icon: this.embedOptions.icons.audioPlaying
+              });
     };
 
-    private getEmbedFields = (currentTrack: Track): EmbedField[] => {
+    private getEmbedFields = (currentTrack: Track, translator: TFunction): EmbedField[] => {
         const fields: EmbedField[] = [
             {
-                name: '**Author**',
-                value: this.getDisplayTrackAuthor(currentTrack),
+                name: translator('commands.nowplaying.embedFields.author'),
+                value: this.getDisplayTrackAuthor(currentTrack, translator),
                 inline: true
             },
             {
-                name: '**Plays**',
-                value: this.getDisplayPlays(currentTrack),
+                name: translator('commands.nowplaying.embedFields.plays'),
+                value: this.getDisplayPlays(currentTrack, translator),
                 inline: true
             },
             {
-                name: '**Track source**',
-                value: this.getDisplayTrackSource(currentTrack),
+                name: translator('commands.nowplaying.embedFields.source'),
+                value: this.getDisplayTrackSource(currentTrack, translator),
                 inline: true
             }
         ];

--- a/src/interactions/commands/player/nowplaying.ts
+++ b/src/interactions/commands/player/nowplaying.ts
@@ -165,12 +165,8 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
 
     private getDisplayTrackPlayingStatus = (queue: GuildQueue, translator: TFunction): string => {
         return queue.node.isPaused()
-            ? translator('musicPlayerCommon.nowPausedTitle', {
-                  icon: this.embedOptions.icons.paused
-              })
-            : translator('musicPlayerCommon.nowPlayingTitle', {
-                  icon: this.embedOptions.icons.audioPlaying
-              });
+            ? translator('musicPlayerCommon.nowPausedTitle', { icon: this.embedOptions.icons.paused })
+            : translator('musicPlayerCommon.nowPlayingTitle', { icon: this.embedOptions.icons.audioPlaying });
     };
 
     private getEmbedFields = (currentTrack: Track, translator: TFunction): EmbedField[] => {

--- a/src/interactions/commands/player/nowplaying.ts
+++ b/src/interactions/commands/player/nowplaying.ts
@@ -14,7 +14,7 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType, TrackMetadata } from '../../../types/interactionTypes';
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
 
 class NowPlayingCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -25,6 +25,7 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -37,11 +38,11 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
 
         const tracksInQueueCount: number = queue.tracks.data.length;
         const currentTrack: Track = queue.currentTrack!;
-        const displayTrackUrl: string = this.getFormattedTrackUrl(currentTrack);
-        const displayTrackRequestedBy: string = this.getDisplayTrackRequestedBy(currentTrack);
+        const displayTrackUrl: string = this.getFormattedTrackUrl(currentTrack, translator);
+        const displayTrackRequestedBy: string = this.getDisplayTrackRequestedBy(currentTrack, translator);
         const displayTrackPlayingStatus: string = this.getDisplayTrackPlayingStatus(queue);
         const displayQueueRepeatMode: string = this.getDisplayQueueRepeatMode(queue);
-        const displayEmbedProgressBar: string = this.getDisplayQueueProgressBar(queue);
+        const displayEmbedProgressBar: string = this.getDisplayQueueProgressBar(queue, translator);
 
         const components: APIMessageActionRowComponent[] = [];
 
@@ -82,7 +83,7 @@ class NowPlayingCommand extends BaseSlashCommandInteraction {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setAuthor(this.getEmbedQueueAuthor(interaction, queue))
+                    .setAuthor(this.getEmbedQueueAuthor(interaction, queue, translator))
                     .setDescription(
                         `${displayTrackPlayingStatus}\n` +
                             `${displayTrackUrl}\n` +

--- a/src/interactions/commands/player/pause.ts
+++ b/src/interactions/commands/player/pause.ts
@@ -5,10 +5,11 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class PauseCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder().setName('pause').setDescription('Toggle pause for the current track.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('pause'));
         super(data);
     }
 

--- a/src/interactions/commands/player/pause.ts
+++ b/src/interactions/commands/player/pause.ts
@@ -5,7 +5,7 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
 
 class PauseCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -16,6 +16,7 @@ class PauseCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -36,9 +37,16 @@ class PauseCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.pauseResumed} ${
-                            queue.node.isPaused() ? 'Paused Track' : 'Resumed track'
-                        }**\n ${this.getDisplayTrackDurationAndUrl(currentTrack)}`
+                        translator(
+                            queue.node.isPaused()
+                                ? 'commands.pause.pauseConfirmation'
+                                : 'commands.pause.resumeConfirmation',
+                            {
+                                icon: this.embedOptions.icons.success
+                            }
+                        ) +
+                            '\n' +
+                            this.getDisplayTrackDurationAndUrl(currentTrack, translator)
                     )
                     .setThumbnail(currentTrack.thumbnail)
                     .setColor(this.embedOptions.colors.success)

--- a/src/interactions/commands/player/play.ts
+++ b/src/interactions/commands/player/play.ts
@@ -6,21 +6,17 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkVoicePermissionJoinAndTalk } from '../../../utils/validation/permissionValidator';
 import { transformQuery } from '../../../utils/validation/searchQueryValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class PlayCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('play')
-            .setDescription('Add a track or playlist to the queue by search query or URL.')
-            .addStringOption((option) =>
-                option
-                    .setName('query')
-                    .setDescription('Search query by text or URL')
-                    .setRequired(true)
-                    .setMinLength(2)
-                    .setMaxLength(500)
-                    .setAutocomplete(true)
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('play')
+                .addStringOption((option) =>
+                    option.setName('query').setRequired(true).setMinLength(2).setMaxLength(500).setAutocomplete(true)
+                )
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/queue.ts
+++ b/src/interactions/commands/player/queue.ts
@@ -120,9 +120,7 @@ class QueueCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedQueueAuthor(interaction, queue, translator))
                     .setDescription(
-                        translator('musicPlayerCommon.nowPlayingTitle', {
-                            icon: this.embedOptions.icons.audioPlaying
-                        }) +
+                        this.getDisplayTrackPlayingStatus(queue, translator) +
                             '\n' +
                             this.getFormattedTrackUrl(currentTrack, translator) +
                             '\n' +
@@ -130,7 +128,7 @@ class QueueCommand extends BaseSlashCommandInteraction {
                                 user: this.getDisplayTrackRequestedBy(currentTrack, translator)
                             }) +
                             '\n' +
-                            `${this.getDisplayQueueProgressBar(queue, translator)}\n\n` +
+                            `${this.getDisplayQueueProgressBar(queue, translator)}\n` +
                             `${formatRepeatModeDetailed(queue.repeatMode, this.embedOptions, translator)}\n` +
                             `${translator('commands.queue.tracksInQueueTitle', {
                                 icon: this.embedOptions.icons.queue
@@ -145,6 +143,12 @@ class QueueCommand extends BaseSlashCommandInteraction {
         });
         return Promise.resolve();
     }
+
+    private getDisplayTrackPlayingStatus = (queue: GuildQueue, translator: TFunction): string => {
+        return queue.node.isPaused()
+            ? translator('musicPlayerCommon.nowPausedTitle', { icon: this.embedOptions.icons.paused })
+            : translator('musicPlayerCommon.nowPlayingTitle', { icon: this.embedOptions.icons.audioPlaying });
+    };
 
     private async handleNoCurrentTrack(
         logger: Logger,

--- a/src/interactions/commands/player/queue.ts
+++ b/src/interactions/commands/player/queue.ts
@@ -16,7 +16,7 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
-import { formatDuration } from '../../../common/formattingUtils';
+import { formatDuration, formatRepeatModeDetailed } from '../../../common/formattingUtils';
 import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
 import { TFunction } from 'i18next';
 
@@ -123,20 +123,18 @@ class QueueCommand extends BaseSlashCommandInteraction {
                         translator('musicPlayerCommon.nowPlayingTitle', {
                             icon: this.embedOptions.icons.audioPlaying
                         }) +
+                            '\n' +
                             this.getFormattedTrackUrl(currentTrack, translator) +
                             '\n' +
                             translator('musicPlayerCommon.requestedBy', {
                                 user: this.getDisplayTrackRequestedBy(currentTrack, translator)
                             }) +
                             '\n' +
-                            this.getDisplayQueueProgressBar(queue, translator) +
-                            '\n' +
-                            '\n' +
-                            this.getDisplayRepeatMode(queue.repeatMode, translator) +
-                            translator('commands.queue.tracksInQueueTitle', {
+                            `${this.getDisplayQueueProgressBar(queue, translator)}\n\n` +
+                            `${formatRepeatModeDetailed(queue.repeatMode, this.embedOptions, translator)}\n` +
+                            `${translator('commands.queue.tracksInQueueTitle', {
                                 icon: this.embedOptions.icons.queue
-                            }) +
-                            '\n' +
+                            })}\n` +
                             queueTracksListString
                     )
                     .setThumbnail(this.getTrackThumbnailUrl(currentTrack))
@@ -163,8 +161,10 @@ class QueueCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedQueueAuthor(interaction, queue, translator))
                     .setDescription(
-                        `${this.getDisplayRepeatMode(queue.repeatMode, translator)}` +
-                            `**${this.embedOptions.icons.queue} Tracks in queue**\n` +
+                        `${formatRepeatModeDetailed(queue.repeatMode, this.embedOptions, translator)}` +
+                            `${translator('commands.queue.tracksInQueueTitle', {
+                                icon: this.embedOptions.icons.queue
+                            })}\n` +
                             queueTracksListString
                     )
                     .setFooter(this.getDisplayFullFooterInfo(interaction, queue, translator))

--- a/src/interactions/commands/player/queue.ts
+++ b/src/interactions/commands/player/queue.ts
@@ -17,15 +17,15 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { formatDuration } from '../../../common/formattingUtils';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class QueueCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('queue')
-            .setDescription('Show tracks that have been added to the queue.')
-            .addIntegerOption((option) =>
-                option.setName('page').setDescription('Page number to display for the queue').setMinValue(1)
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('queue')
+                .addIntegerOption((option) => option.setName('page').setMinValue(1))
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/remove.ts
+++ b/src/interactions/commands/player/remove.ts
@@ -5,6 +5,9 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
+import { TFunction } from 'i18next';
+import { useServerTranslator } from '../../../common/localeUtil';
+import { formatSlashCommand } from '../../../common/formattingUtils';
 
 class RemoveCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -63,6 +66,7 @@ class RemoveCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -76,21 +80,26 @@ class RemoveCommand extends BaseSlashCommandInteraction {
 
         switch (subcommand) {
             case 'track':
-                return await this.handleRemovedTrack(logger, interaction, queue);
+                return await this.handleRemovedTrack(logger, interaction, queue, translator);
             case 'range':
-                return await this.handleRemoveRange(logger, interaction, queue);
+                return await this.handleRemoveRange(logger, interaction, queue, translator);
             case 'queue':
-                return await this.handleRemoveQueue(logger, interaction, queue);
+                return await this.handleRemoveQueue(logger, interaction, queue, translator);
             case 'user':
-                return await this.handleRemoveUserTracks(logger, interaction, queue);
+                return await this.handleRemoveUserTracks(logger, interaction, queue, translator);
             case 'duplicates':
-                return await this.handleRemoveDuplicates(logger, interaction, queue);
+                return await this.handleRemoveDuplicates(logger, interaction, queue, translator);
             default:
                 return Promise.resolve();
         }
     }
 
-    private async handleRemoveUserTracks(logger: Logger, interaction: ChatInputCommandInteraction, queue: GuildQueue) {
+    private async handleRemoveUserTracks(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        queue: GuildQueue,
+        translator: TFunction
+    ) {
         const targetUser = interaction.options.getUser('target')!;
         const removedTracks: Track[] = [];
         queue.tracks.data.forEach((track) => {
@@ -103,15 +112,20 @@ class RemoveCommand extends BaseSlashCommandInteraction {
         });
 
         if (removedTracks.length === 0) {
-            return await this.handleNoTracksRemoved(logger, interaction);
+            return await this.handleNoTracksRemoved(logger, interaction, translator);
         }
 
         logger.debug(`Removed ${removedTracks.length} tracks from queue added by a user.`);
 
-        return await this.handleResponseRemovedTracks(logger, interaction, removedTracks.length);
+        return await this.handleResponseRemovedTracks(logger, interaction, removedTracks.length, translator);
     }
 
-    private async handleRemoveDuplicates(logger: Logger, interaction: ChatInputCommandInteraction, queue: GuildQueue) {
+    private async handleRemoveDuplicates(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        queue: GuildQueue,
+        translator: TFunction
+    ) {
         const removedTracks: Track[] = [];
         const uniqueTrackUrls = new Set<string>();
         queue.tracks.data.forEach((track) => {
@@ -126,20 +140,25 @@ class RemoveCommand extends BaseSlashCommandInteraction {
         });
 
         if (removedTracks.length === 0) {
-            return await this.handleNoTracksRemoved(logger, interaction);
+            return await this.handleNoTracksRemoved(logger, interaction, translator);
         }
 
         logger.debug(`Removed ${removedTracks.length} duplicate tracks from queue.`);
 
-        return await this.handleResponseRemovedTracks(logger, interaction, removedTracks.length);
+        return await this.handleResponseRemovedTracks(logger, interaction, removedTracks.length, translator);
     }
 
-    private async handleRemoveRange(logger: Logger, interaction: ChatInputCommandInteraction, queue: GuildQueue) {
+    private async handleRemoveRange(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        queue: GuildQueue,
+        translator: TFunction
+    ) {
         const start: number = interaction.options.getInteger('start')!;
         const end: number = interaction.options.getInteger('end')!;
 
         if (start > queue.tracks.data.length || end > queue.tracks.data.length) {
-            return await this.handleTrackPositionHigherThanQueueLength(logger, interaction, start, queue);
+            return await this.handleTrackPositionHigherThanQueueLength(logger, interaction, start, queue, translator);
         } else if (start > end) {
             logger.debug('Start position is higher than end position.');
 
@@ -148,9 +167,12 @@ class RemoveCommand extends BaseSlashCommandInteraction {
                 embeds: [
                     new EmbedBuilder()
                         .setDescription(
-                            `**${this.embedOptions.icons.warning} Oops!**\n` +
-                                `Start position **\`${start}\`** is higher than end position **\`${end}\`**. Please specify a valid range.` +
-                                '\n\nView tracks added to the queue with **`/queue`**.'
+                            translator('commands.remove.startPositionHigherThanEndPosition', {
+                                icon: this.embedOptions.icons.warning,
+                                start,
+                                end,
+                                queueCommand: formatSlashCommand('queue', translator)
+                            })
                         )
                         .setColor(this.embedOptions.colors.warning)
                 ]
@@ -167,32 +189,48 @@ class RemoveCommand extends BaseSlashCommandInteraction {
         }
 
         if (removedTracks.length === 0) {
-            return await this.handleNoTracksRemoved(logger, interaction);
+            return await this.handleNoTracksRemoved(logger, interaction, translator);
         }
 
         logger.debug(`Removed ${removedTracks.length} tracks from queue.`);
 
-        return await this.handleResponseRemovedTracks(logger, interaction, removedTracks.length);
+        return await this.handleResponseRemovedTracks(logger, interaction, removedTracks.length, translator);
     }
 
-    private async handleRemoveQueue(logger: Logger, interaction: ChatInputCommandInteraction, queue: GuildQueue) {
+    private async handleRemoveQueue(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        queue: GuildQueue,
+        translator: TFunction
+    ) {
         const queueLength = queue.tracks.data.length;
         queue.clear();
 
         if (queueLength === 0) {
-            return await this.handleNoTracksRemoved(logger, interaction);
+            return await this.handleNoTracksRemoved(logger, interaction, translator);
         }
 
         logger.debug('Cleared the queue and removed all tracks.');
 
-        return await this.handleResponseRemovedTracks(logger, interaction, queueLength);
+        return await this.handleResponseRemovedTracks(logger, interaction, queueLength, translator);
     }
 
-    private async handleRemovedTrack(logger: Logger, interaction: ChatInputCommandInteraction, queue: GuildQueue) {
+    private async handleRemovedTrack(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        queue: GuildQueue,
+        translator: TFunction
+    ) {
         const trackPositionInput: number = interaction.options.getInteger('position')!;
 
         if (trackPositionInput > queue.tracks.data.length) {
-            return await this.handleTrackPositionHigherThanQueueLength(logger, interaction, trackPositionInput, queue);
+            return await this.handleTrackPositionHigherThanQueueLength(
+                logger,
+                interaction,
+                trackPositionInput,
+                queue,
+                translator
+            );
         }
 
         const removedTrack: Track = queue.node.remove(trackPositionInput - 1)!;
@@ -204,9 +242,11 @@ class RemoveCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.success} Removed track**\n${this.getDisplayTrackDurationAndUrl(
-                            removedTrack
-                        )}`
+                        translator('commands.remove.removedTrack', {
+                            icon: this.embedOptions.icons.success
+                        }) +
+                            '\n' +
+                            this.getDisplayTrackDurationAndUrl(removedTrack, translator)
                     )
                     .setThumbnail(this.getTrackThumbnailUrl(removedTrack))
                     .setColor(this.embedOptions.colors.success)
@@ -215,15 +255,20 @@ class RemoveCommand extends BaseSlashCommandInteraction {
         return Promise.resolve();
     }
 
-    private async handleNoTracksRemoved(logger: Logger, interaction: ChatInputCommandInteraction) {
+    private async handleNoTracksRemoved(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
+    ) {
         logger.debug('Responding with warning embed.');
         await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} No tracks removed**\n` +
-                            'There were no tracks removed from the queue. Please check if the option you selected has tracks to remove.'
+                        translator('commands.remove.noTracksRemoved', {
+                            icon: this.embedOptions.icons.warning
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ]
@@ -234,7 +279,8 @@ class RemoveCommand extends BaseSlashCommandInteraction {
     private async handleResponseRemovedTracks(
         logger: Logger,
         interaction: ChatInputCommandInteraction,
-        removedAmount: number
+        removedAmount: number,
+        translator: TFunction
     ) {
         logger.debug('Responding with success embed.');
         await interaction.editReply({
@@ -242,8 +288,10 @@ class RemoveCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.success} Removed tracks**\n` +
-                            `**\`${removedAmount}\`** tracks were removed from the queue.`
+                        translator('commands.remove.removedTracks', {
+                            icon: this.embedOptions.icons.success,
+                            count: removedAmount
+                        })
                     )
                     .setColor(this.embedOptions.colors.success)
             ]
@@ -255,7 +303,8 @@ class RemoveCommand extends BaseSlashCommandInteraction {
         logger: Logger,
         interaction: ChatInputCommandInteraction,
         trackPositionInput: number,
-        queue: GuildQueue
+        queue: GuildQueue,
+        translator: TFunction
     ) {
         logger.debug('Specified track position is higher than total tracks.');
 
@@ -264,9 +313,12 @@ class RemoveCommand extends BaseSlashCommandInteraction {
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\n` +
-                            `Position **\`${trackPositionInput}\`** is not a valid track position. There are only a total of **\`${queue.tracks.data.length}\`** tracks in the queue.` +
-                            '\n\nView tracks added to the queue with **`/queue`**.'
+                        translator('commands.skip.trackPositionHigherThanQueueLength', {
+                            icon: this.embedOptions.icons.warning,
+                            position: trackPositionInput,
+                            count: queue.tracks.data.length,
+                            queueCommand: formatSlashCommand('queue', translator)
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ]

--- a/src/interactions/commands/player/remove.ts
+++ b/src/interactions/commands/player/remove.ts
@@ -8,6 +8,7 @@ import { Logger } from 'pino';
 
 class RemoveCommand extends BaseSlashCommandInteraction {
     constructor() {
+        // TODO: Add subcommand localization support
         const data = new SlashCommandBuilder()
             .setName('remove')
             .setDescription('Remove tracks from the queue')

--- a/src/interactions/commands/player/seek.ts
+++ b/src/interactions/commands/player/seek.ts
@@ -5,15 +5,15 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class SeekCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('seek')
-            .setDescription('Seek to a duration in the current track.')
-            .addStringOption((option) =>
-                option.setName('duration').setDescription('Duration in format 00:00:00 (HH:mm:ss).').setRequired(true)
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('seek')
+                .addStringOption((option) => option.setName('duration').setRequired(true))
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/shuffle.ts
+++ b/src/interactions/commands/player/shuffle.ts
@@ -4,12 +4,11 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueEmpty, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class ShuffleCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('shuffle')
-            .setDescription('Randomly shuffle all tracks in the queue.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('shuffle'));
         super(data);
     }
 

--- a/src/interactions/commands/player/shuffle.ts
+++ b/src/interactions/commands/player/shuffle.ts
@@ -4,7 +4,8 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueEmpty, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { formatSlashCommand } from '../../../common/formattingUtils';
 
 class ShuffleCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -15,6 +16,7 @@ class ShuffleCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -34,9 +36,11 @@ class ShuffleCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.shuffled} Shuffled queue tracks**\n` +
-                            `The **${queue.tracks.data.length}** tracks in the queue has been shuffled.\n\n` +
-                            'View the new queue order with **`/queue`**.'
+                        translator('commands.shuffle.shuffledTracks', {
+                            icon: this.embedOptions.icons.shuffled,
+                            count: queue.tracks.data.length,
+                            queueCommand: formatSlashCommand('queue', translator)
+                        })
                     )
                     .setColor(this.embedOptions.colors.success)
             ]

--- a/src/interactions/commands/player/skip.ts
+++ b/src/interactions/commands/player/skip.ts
@@ -5,7 +5,9 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { TFunction } from 'i18next';
+import { formatSlashCommand } from '../../../common/formattingUtils';
 
 class SkipCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -20,6 +22,7 @@ class SkipCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -33,9 +36,9 @@ class SkipCommand extends BaseSlashCommandInteraction {
         const trackPositionInput: number = interaction.options.getInteger('position')!;
 
         if (trackPositionInput) {
-            return await this.handleSkipToTrackPosition(logger, interaction, queue, trackPositionInput);
+            return await this.handleSkipToTrackPosition(logger, interaction, queue, trackPositionInput, translator);
         } else {
-            return await this.handleSkipToNextTrack(logger, interaction, queue);
+            return await this.handleSkipToNextTrack(logger, interaction, queue, translator);
         }
     }
 
@@ -43,15 +46,22 @@ class SkipCommand extends BaseSlashCommandInteraction {
         logger: Logger,
         interaction: ChatInputCommandInteraction,
         queue: GuildQueue,
-        trackPosition: number
+        trackPosition: number,
+        translator: TFunction
     ) {
         if (trackPosition > queue.tracks.data.length) {
-            return await this.handleTrackPositionHigherThanQueueLength(trackPosition, queue, logger, interaction);
+            return await this.handleTrackPositionHigherThanQueueLength(
+                trackPosition,
+                queue,
+                logger,
+                interaction,
+                translator
+            );
         } else {
             const skippedTrack: Track = queue.currentTrack!;
             queue.node.skipTo(trackPosition - 1);
             logger.debug('Skipped to specified track position.');
-            return await this.respondWithSuccessEmbed(skippedTrack, interaction);
+            return await this.respondWithSuccessEmbed(skippedTrack, interaction, translator);
         }
     }
 
@@ -59,55 +69,77 @@ class SkipCommand extends BaseSlashCommandInteraction {
         trackPosition: number,
         queue: GuildQueue,
         logger: Logger,
-        interaction: ChatInputCommandInteraction
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
     ) {
         logger.debug('Specified track position was higher than total tracks.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\n` +
-                            `There are only **\`${queue.tracks.data.length}\`** tracks in the queue. You cannot skip to track **\`${trackPosition}\`**.\n\n` +
-                            'View tracks added to the queue with **`/queue`**.'
+                        translator('commands.skip.trackPositionHigherThanQueueLength', {
+                            icon: this.embedOptions.icons.warning,
+                            position: trackPosition,
+                            queueCommand: formatSlashCommand('queue', translator),
+                            count: queue.tracks.data.length
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ]
         });
     }
 
-    private async handleSkipToNextTrack(logger: Logger, interaction: ChatInputCommandInteraction, queue: GuildQueue) {
+    private async handleSkipToNextTrack(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        queue: GuildQueue,
+        translator: TFunction
+    ) {
         if (queue.tracks.data.length === 0 && !queue.currentTrack) {
-            return await this.handleNoTracksInQueueAndNoCurrentTrack(logger, interaction);
+            return await this.handleNoTracksInQueueAndNoCurrentTrack(logger, interaction, translator);
         }
 
         const skippedTrack: Track = queue.currentTrack!;
         queue.node.skip();
         logger.debug('Skipped current track.');
-        return await this.respondWithSuccessEmbed(skippedTrack, interaction);
+        return await this.respondWithSuccessEmbed(skippedTrack, interaction, translator);
     }
 
-    private async handleNoTracksInQueueAndNoCurrentTrack(logger: Logger, interaction: ChatInputCommandInteraction) {
+    private async handleNoTracksInQueueAndNoCurrentTrack(
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
+    ) {
         logger.debug('No tracks in queue and no current track.');
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\n` +
-                            'The queue is empty, add some tracks with **`/play`**!'
+                        translator('commands.skip.emptyQueue', {
+                            icon: this.embedOptions.icons.warning,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ]
         });
     }
 
-    private async respondWithSuccessEmbed(skippedTrack: Track, interaction: ChatInputCommandInteraction) {
+    private async respondWithSuccessEmbed(
+        skippedTrack: Track,
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
+    ) {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.skipped} Skipped track**\n` +
-                            `${this.getDisplayTrackDurationAndUrl(skippedTrack)}`
+                        translator('commands.skip.skippedTrack', {
+                            icon: this.embedOptions.icons.skipped
+                        }) +
+                            '\n' +
+                            this.getDisplayTrackDurationAndUrl(skippedTrack, translator)
                     )
                     .setThumbnail(this.getTrackThumbnailUrl(skippedTrack))
                     .setColor(this.embedOptions.colors.success)

--- a/src/interactions/commands/player/skip.ts
+++ b/src/interactions/commands/player/skip.ts
@@ -5,15 +5,15 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkQueueCurrentTrack, checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class SkipCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('skip')
-            .setDescription('Skip track to next or specified position in queue.')
-            .addIntegerOption((option) =>
-                option.setName('position').setDescription('The position in queue to skip to.').setMinValue(1)
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('skip')
+                .addIntegerOption((option) => option.setName('position').setMinValue(1))
+        );
         super(data);
     }
 

--- a/src/interactions/commands/player/stop.ts
+++ b/src/interactions/commands/player/stop.ts
@@ -1,4 +1,4 @@
-import { GuildQueue, useQueue } from 'discord-player';
+import { GuildQueue, QueueRepeatMode, useQueue } from 'discord-player';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
@@ -27,7 +27,7 @@ class StopCommand extends BaseSlashCommandInteraction {
         ]);
 
         if (!queue.deleted) {
-            queue.setRepeatMode(0);
+            queue.setRepeatMode(QueueRepeatMode.OFF);
             queue.clear();
             queue.node.stop();
             logger.debug('Cleared and stopped the queue.');

--- a/src/interactions/commands/player/stop.ts
+++ b/src/interactions/commands/player/stop.ts
@@ -4,7 +4,8 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { formatSlashCommand } from '../../../common/formattingUtils';
 
 class StopCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -15,6 +16,7 @@ class StopCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -37,9 +39,10 @@ class StopCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.success} Stopped playing**\n` +
-                            'Stopped playing audio and cleared the track queue.\n\n' +
-                            'To play more music, use the **`/play`** command!'
+                        translator('commands.stop.stoppedPlaying', {
+                            icon: this.embedOptions.icons.success,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(this.embedOptions.colors.success)
             ]

--- a/src/interactions/commands/player/stop.ts
+++ b/src/interactions/commands/player/stop.ts
@@ -4,12 +4,11 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class StopCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('stop')
-            .setDescription('Clear the queue and stop playing audio.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('stop'));
         super(data);
     }
 

--- a/src/interactions/commands/player/volume.ts
+++ b/src/interactions/commands/player/volume.ts
@@ -5,7 +5,8 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { TFunction } from 'i18next';
 
 class VolumeCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -20,6 +21,7 @@ class VolumeCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -32,15 +34,20 @@ class VolumeCommand extends BaseSlashCommandInteraction {
         const volume: number = interaction.options.getInteger('percentage')!;
 
         if (!volume && volume !== 0) {
-            return await this.handleShowCurrentVolume(queue, logger, interaction);
+            return await this.handleShowCurrentVolume(queue, logger, interaction, translator);
         } else if (volume > 100 || volume < 0) {
-            return await this.handleInvalidVolumeInput(volume, logger, interaction);
+            return await this.handleInvalidVolumeInput(volume, logger, interaction, translator);
         } else {
-            return await this.handleValidVolumeInput(volume, queue, logger, interaction);
+            return await this.handleValidVolumeInput(volume, queue, logger, interaction, translator);
         }
     }
 
-    private async handleShowCurrentVolume(queue: GuildQueue, logger: Logger, interaction: ChatInputCommandInteraction) {
+    private async handleShowCurrentVolume(
+        queue: GuildQueue,
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
+    ) {
         const currentVolume: number = queue.node.volume;
         logger.debug('No volume input was provided, showing current volume.');
 
@@ -52,15 +59,22 @@ class VolumeCommand extends BaseSlashCommandInteraction {
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${currentVolumeIcon} Playback volume**\n` +
-                            `The playback volume is currently set to **\`${currentVolume}%\`**.`
+                        translator('commands.volume.volumeInformation', {
+                            icon: currentVolumeIcon,
+                            volume: currentVolume
+                        })
                     )
                     .setColor(this.embedOptions.colors.info)
             ]
         });
     }
 
-    private async handleInvalidVolumeInput(volume: number, logger: Logger, interaction: ChatInputCommandInteraction) {
+    private async handleInvalidVolumeInput(
+        volume: number,
+        logger: Logger,
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
+    ) {
         logger.debug('Volume specified was higher than 100% or lower than 0%.');
 
         logger.debug('Responding with warning embed.');
@@ -68,8 +82,10 @@ class VolumeCommand extends BaseSlashCommandInteraction {
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\n` +
-                            `You cannot set the volume to **\`${volume}%\`**, please pick a value betwen **\`1%\`** and **\`100%\`**.`
+                        translator('commands.volume.invalidVolumeRange', {
+                            icon: this.embedOptions.icons.warning,
+                            wrongVolume: volume
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ]
@@ -80,7 +96,8 @@ class VolumeCommand extends BaseSlashCommandInteraction {
         volume: number,
         queue: GuildQueue,
         logger: Logger,
-        interaction: ChatInputCommandInteraction
+        interaction: ChatInputCommandInteraction,
+        translator: TFunction
     ) {
         queue.node.setVolume(volume);
         logger.debug(`Set volume to ${volume}%.`);
@@ -92,8 +109,9 @@ class VolumeCommand extends BaseSlashCommandInteraction {
                     new EmbedBuilder()
                         .setAuthor(this.getEmbedUserAuthor(interaction))
                         .setDescription(
-                            `**${this.embedOptions.icons.volumeMuted} Audio muted**\n` +
-                                `Playback audio has been muted, because volume was set to **\`${volume}%\`**.`
+                            translator('commands.volume.volumeMuted', {
+                                icon: this.embedOptions.icons.volumeMuted
+                            })
                         )
                         .setColor(this.embedOptions.colors.success)
                 ]
@@ -106,8 +124,10 @@ class VolumeCommand extends BaseSlashCommandInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.volumeChanged} Volume changed**\n` +
-                            `Playback volume has been changed to **\`${volume}%\`**.`
+                        translator('commands.volume.volumeChanged', {
+                            icon: this.embedOptions.icons.volumeChanged,
+                            volume
+                        })
                     )
                     .setColor(this.embedOptions.colors.success)
             ]

--- a/src/interactions/commands/player/volume.ts
+++ b/src/interactions/commands/player/volume.ts
@@ -5,19 +5,15 @@ import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../typ
 import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class VolumeCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('volume')
-            .setDescription('Show or change the playback volume for tracks.')
-            .addIntegerOption((option) =>
-                option
-                    .setName('percentage')
-                    .setDescription('Volume percentage: From 1% to 100%.')
-                    .setMinValue(0)
-                    .setMaxValue(100)
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('volume')
+                .addIntegerOption((option) => option.setName('percentage').setMinValue(0).setMaxValue(100))
+        );
         super(data);
     }
 

--- a/src/interactions/commands/system/guilds.ts
+++ b/src/interactions/commands/system/guilds.ts
@@ -4,7 +4,8 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { ExtendedClient } from '../../../types/clientTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { TFunction } from 'i18next';
 
 class GuildsCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -16,6 +17,7 @@ class GuildsCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction, client } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         await this.runValidators({ interaction, executionId }, [checkValidGuildId]);
 
@@ -27,7 +29,12 @@ class GuildsCommand extends BaseSlashCommandInteraction {
         const guildListFormatted = this.formatGuildListAsString(shardGuilds);
         const totalMemberCount = this.calculateTotalMemberCount(shardGuilds);
 
-        let embedDescription = this.buildEmbedDescription(totalGuildCount, guildListFormatted, totalMemberCount);
+        let embedDescription = this.buildEmbedDescription(
+            totalGuildCount,
+            guildListFormatted,
+            totalMemberCount,
+            translator
+        );
 
         if (embedDescription.length >= 4000) {
             logger.debug('Embed description is too long, truncating.');
@@ -71,13 +78,23 @@ class GuildsCommand extends BaseSlashCommandInteraction {
     private buildEmbedDescription(
         totalGuildCount: number,
         guildListFormattedString: string,
-        totalMemberCount: number
+        totalMemberCount: number,
+        translator: TFunction
     ): string {
-        const topGuildsString = totalGuildCount < 25 ? `Top ${totalGuildCount} guilds` : 'Top 25 guilds';
+        const guildCount = Math.max(totalGuildCount, 25);
         return (
-            `**${this.embedOptions.icons.bot} ${topGuildsString} by member count (${totalGuildCount} total)**\n` +
-            `${guildListFormattedString}\n\n` +
-            `**Total members:** **\`${totalMemberCount}\`**`
+            translator('commands.guilds.topGuildsByMemberCount', {
+                icon: this.embedOptions.icons.bot,
+                count: guildCount,
+                totalCount: totalGuildCount
+            }) +
+            '\n' +
+            guildListFormattedString +
+            '\n' +
+            '\n' +
+            translator('commands.guilds.totalMembers', {
+                count: totalMemberCount
+            })
         );
     }
 }

--- a/src/interactions/commands/system/guilds.ts
+++ b/src/interactions/commands/system/guilds.ts
@@ -4,12 +4,11 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { ExtendedClient } from '../../../types/clientTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class GuildsCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('guilds')
-            .setDescription('Show the top 25 guilds by member count.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('guilds'));
         const isSystemCommand: boolean = true;
         super(data, isSystemCommand);
     }

--- a/src/interactions/commands/system/reload.ts
+++ b/src/interactions/commands/system/reload.ts
@@ -10,7 +10,8 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { ExtendedClient } from '../../../types/clientTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
+import { TFunction } from 'i18next';
 
 class ReloadCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -22,16 +23,17 @@ class ReloadCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction, client } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         await this.runValidators({ interaction, executionId }, [checkValidGuildId]);
 
         try {
             await this.reloadInteractionsAcrossShards(logger, executionId, client!);
         } catch (error) {
-            return await this.handleReloadError(logger, interaction, executionId, error);
+            return await this.handleReloadError(logger, interaction, executionId, error, translator);
         }
 
-        return await this.respondWithSuccessEmbed(logger, interaction, client!);
+        return await this.respondWithSuccessEmbed(logger, interaction, client!, translator);
     }
 
     private async reloadInteractionsAcrossShards(logger: Logger, executionId: string, client: ExtendedClient) {
@@ -49,7 +51,8 @@ class ReloadCommand extends BaseSlashCommandInteraction {
         logger: Logger,
         interaction: ChatInputCommandInteraction,
         executionId: string,
-        error: Error | unknown
+        error: Error | unknown,
+        translator: TFunction
     ) {
         logger.error(error, 'Failed to reload interaction module across shards.');
 
@@ -58,8 +61,9 @@ class ReloadCommand extends BaseSlashCommandInteraction {
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.error} Oops!**\n` +
-                            '_Hmm.._ It seems I am unable to reload interaction module across shards.'
+                        translator('commands.reload.unableToReload', {
+                            icon: this.embedOptions.icons.error
+                        })
                     )
                     .setColor(this.embedOptions.colors.error)
                     .setFooter({ text: `Execution ID: ${executionId}` })
@@ -70,10 +74,11 @@ class ReloadCommand extends BaseSlashCommandInteraction {
     private async respondWithSuccessEmbed(
         logger: Logger,
         interaction: ChatInputCommandInteraction,
-        client: ExtendedClient
+        client: ExtendedClient,
+        translator: TFunction
     ) {
         const commands = this.getCommands(client);
-        const embedDescription = this.buildEmbedDescription(commands);
+        const embedDescription = this.buildEmbedDescription(commands, translator);
 
         logger.debug('Responding with success embed.');
         return await interaction.editReply({
@@ -102,8 +107,14 @@ class ReloadCommand extends BaseSlashCommandInteraction {
         return params;
     }
 
-    private buildEmbedDescription(commands: string[] | undefined): string {
-        return `**${this.embedOptions.icons.bot} Reloaded commands**\n` + commands?.join('\n');
+    private buildEmbedDescription(commands: string[] | undefined, translator: TFunction): string {
+        return (
+            translator('commands.reload.reloadedCommands', {
+                icon: this.embedOptions.icons.bot
+            }) +
+            '\n' +
+            commands?.join('\n')
+        );
     }
 }
 

--- a/src/interactions/commands/system/reload.ts
+++ b/src/interactions/commands/system/reload.ts
@@ -10,12 +10,11 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { ExtendedClient } from '../../../types/clientTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class ReloadCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('reload')
-            .setDescription('Reload slash command, autocomplete and component interactions across shards.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('reload'));
         const isSystemCommand: boolean = true;
         super(data, isSystemCommand);
     }

--- a/src/interactions/commands/system/shards.ts
+++ b/src/interactions/commands/system/shards.ts
@@ -14,7 +14,6 @@ import { localizeCommand } from '../../../common/localeUtil';
 
 class ShardsCommand extends BaseSlashCommandInteraction {
     constructor() {
-        // TODO: Localize choices
         const data = localizeCommand(
             new SlashCommandBuilder()
                 .setName('shards')
@@ -23,13 +22,13 @@ class ShardsCommand extends BaseSlashCommandInteraction {
                         .setName('sort')
                         .setRequired(false)
                         .addChoices(
-                            { name: 'None (Shard ID)', value: 'none' },
-                            { name: 'Memory usage', value: 'memory' },
-                            { name: 'Voice Connections', value: 'connections' },
-                            { name: 'Tracks', value: 'tracks' },
-                            { name: 'Listeners', value: 'listeners' },
-                            { name: 'Guilds', value: 'guilds' },
-                            { name: 'Members', value: 'members' }
+                            { value: 'none', name: ' ' },
+                            { value: 'memory', name: ' ' },
+                            { value: 'connections', name: ' ' },
+                            { value: 'tracks', name: ' ' },
+                            { value: 'listeners', name: ' ' },
+                            { value: 'guilds', name: ' ' },
+                            { value: 'members', name: ' ' }
                         )
                 )
                 .addIntegerOption((option) => option.setName('page').setMinValue(1))

--- a/src/interactions/commands/system/shards.ts
+++ b/src/interactions/commands/system/shards.ts
@@ -10,30 +10,30 @@ import { ExtendedClient } from '../../../types/clientTypes';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType, ShardInfo } from '../../../types/interactionTypes';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
 import { Logger } from 'pino';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class ShardsCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('shards')
-            .setDescription('Show information about all connected shards.')
-            .addStringOption((option) =>
-                option
-                    .setName('sort')
-                    .setDescription('What to sort the shards by.')
-                    .setRequired(false)
-                    .addChoices(
-                        { name: 'None (Shard ID)', value: 'none' },
-                        { name: 'Memory usage', value: 'memory' },
-                        { name: 'Voice Connections', value: 'connections' },
-                        { name: 'Tracks', value: 'tracks' },
-                        { name: 'Listeners', value: 'listeners' },
-                        { name: 'Guilds', value: 'guilds' },
-                        { name: 'Members', value: 'members' }
-                    )
-            )
-            .addIntegerOption((option) =>
-                option.setName('page').setDescription('Page number to display for the shards').setMinValue(1)
-            );
+        // TODO: Localize choices
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('shards')
+                .addStringOption((option) =>
+                    option
+                        .setName('sort')
+                        .setRequired(false)
+                        .addChoices(
+                            { name: 'None (Shard ID)', value: 'none' },
+                            { name: 'Memory usage', value: 'memory' },
+                            { name: 'Voice Connections', value: 'connections' },
+                            { name: 'Tracks', value: 'tracks' },
+                            { name: 'Listeners', value: 'listeners' },
+                            { name: 'Guilds', value: 'guilds' },
+                            { name: 'Members', value: 'members' }
+                        )
+                )
+                .addIntegerOption((option) => option.setName('page').setMinValue(1))
+        );
         const isSystemCommand: boolean = true;
         super(data, isSystemCommand);
     }

--- a/src/interactions/commands/system/systemstatus.ts
+++ b/src/interactions/commands/system/systemstatus.ts
@@ -5,12 +5,11 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { getBotStatistics, getDiscordStatus, getPlayerStatistics, getSystemStatus } from '../../../common/statusUtils';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
+import { localizeCommand } from '../../../common/localeUtil';
 
 class SystemStatusCommand extends BaseSlashCommandInteraction {
     constructor() {
-        const data = new SlashCommandBuilder()
-            .setName('systemstatus')
-            .setDescription('Show operational status of the bot with additional technical information.');
+        const data = localizeCommand(new SlashCommandBuilder().setName('systemstatus'));
         const isSystemCommand: boolean = true;
         super(data, isSystemCommand);
     }

--- a/src/interactions/commands/system/systemstatus.ts
+++ b/src/interactions/commands/system/systemstatus.ts
@@ -5,7 +5,7 @@ import { BaseSlashCommandInteraction } from '../../../classes/interactions';
 import { getBotStatistics, getDiscordStatus, getPlayerStatistics, getSystemStatus } from '../../../common/statusUtils';
 import { BaseSlashCommandParams, BaseSlashCommandReturnType } from '../../../types/interactionTypes';
 import { checkValidGuildId } from '../../../utils/validation/systemCommandValidator';
-import { localizeCommand } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
 
 class SystemStatusCommand extends BaseSlashCommandInteraction {
     constructor() {
@@ -17,15 +17,16 @@ class SystemStatusCommand extends BaseSlashCommandInteraction {
     async execute(params: BaseSlashCommandParams): BaseSlashCommandReturnType {
         const { executionId, interaction, client } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         await this.runValidators({ interaction, executionId }, [checkValidGuildId]);
 
         const [botStatisticsEmbedString, playerStatisticsEmbedString, systemStatusEmbedString] = await Promise.all([
-            getBotStatistics(client!, version),
-            getPlayerStatistics(client!),
-            getSystemStatus(executionId, false)
+            getBotStatistics(client!, version, translator),
+            getPlayerStatistics(client!, translator),
+            getSystemStatus(executionId, false, translator)
         ]);
-        const discordStatusEmbedString = getDiscordStatus(client!);
+        const discordStatusEmbedString = getDiscordStatus(client!, translator);
         const dependenciesEmbedString = this.getDependencies();
 
         logger.debug('Responding with info embed.');
@@ -35,19 +36,27 @@ class SystemStatusCommand extends BaseSlashCommandInteraction {
                     .setDescription(`**${this.embedOptions.icons.bot} Bot status**\n` + botStatisticsEmbedString)
                     .addFields(
                         {
-                            name: `**${this.embedOptions.icons.queue} Queue status**`,
+                            name: translator('statistics.queueStatus.title', {
+                                icon: this.embedOptions.icons.queue
+                            }),
                             value: playerStatisticsEmbedString
                         },
                         {
-                            name: `**${this.embedOptions.icons.server} System status**`,
+                            name: translator('statistics.systemStatus.title', {
+                                icon: this.embedOptions.icons.server
+                            }),
                             value: systemStatusEmbedString
                         },
                         {
-                            name: `**${this.embedOptions.icons.discord} Discord status**`,
+                            name: translator('statistics.discordStatus.title', {
+                                icon: this.embedOptions.icons.discord
+                            }),
                             value: discordStatusEmbedString
                         },
                         {
-                            name: `**${this.embedOptions.icons.bot} Dependencies**`,
+                            name: translator('statistics.dependencies.title', {
+                                icon: this.embedOptions.icons.bot
+                            }),
                             value: dependenciesEmbedString
                         }
                     )

--- a/src/interactions/components/action-pauseresume-button.ts
+++ b/src/interactions/components/action-pauseresume-button.ts
@@ -6,6 +6,7 @@ import { checkQueueCurrentTrack, checkQueueExists } from '../../utils/validation
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../utils/validation/voiceChannelValidator';
 import { TFunction } from 'i18next';
 import { useServerTranslator } from '../../common/localeUtil';
+import { formatRepeatModeDetailed } from '../../common/formattingUtils';
 
 class ActionPauseResumeButton extends BaseComponentInteraction {
     constructor() {
@@ -85,7 +86,7 @@ class ActionPauseResumeButton extends BaseComponentInteraction {
                 `**${this.embedOptions.icons.pauseResumed} ${
                     queue.node.isPaused() ? 'Paused Track' : 'Resumed track'
                 }**\n ${this.getDisplayTrackDurationAndUrl(queue.currentTrack!, translator)}\n\n` +
-                    `${this.getDisplayRepeatMode(queue.repeatMode, translator, 'success')}`
+                    `${formatRepeatModeDetailed(queue.repeatMode, this.embedOptions, translator, 'success')}`
             )
             .setThumbnail(track.thumbnail)
             .setColor(this.embedOptions.colors.success);

--- a/src/interactions/components/action-pauseresume-button.ts
+++ b/src/interactions/components/action-pauseresume-button.ts
@@ -4,6 +4,8 @@ import { BaseComponentInteraction } from '../../classes/interactions';
 import { BaseComponentParams, BaseComponentReturnType } from '../../types/interactionTypes';
 import { checkQueueCurrentTrack, checkQueueExists } from '../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../utils/validation/voiceChannelValidator';
+import { TFunction } from 'i18next';
+import { useServerTranslator } from '../../common/localeUtil';
 
 class ActionPauseResumeButton extends BaseComponentInteraction {
     constructor() {
@@ -13,6 +15,7 @@ class ActionPauseResumeButton extends BaseComponentInteraction {
     async execute(params: BaseComponentParams): BaseComponentReturnType {
         const { executionId, interaction, referenceId } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -41,7 +44,7 @@ class ActionPauseResumeButton extends BaseComponentInteraction {
         }
 
         logger.debug('Responding with success embed.');
-        return await this.handleSuccess(interaction, currentTrack, queue);
+        return await this.handleSuccess(interaction, currentTrack, queue, translator);
     }
 
     private async handleNoQueue(interaction: MessageComponentInteraction) {
@@ -70,14 +73,19 @@ class ActionPauseResumeButton extends BaseComponentInteraction {
         });
     }
 
-    private async handleSuccess(interaction: MessageComponentInteraction, track: Track, queue: GuildQueue) {
+    private async handleSuccess(
+        interaction: MessageComponentInteraction,
+        track: Track,
+        queue: GuildQueue,
+        translator: TFunction
+    ) {
         const successEmbed = new EmbedBuilder()
             .setAuthor(this.getEmbedUserAuthor(interaction))
             .setDescription(
                 `**${this.embedOptions.icons.pauseResumed} ${
                     queue.node.isPaused() ? 'Paused Track' : 'Resumed track'
-                }**\n ${this.getDisplayTrackDurationAndUrl(queue.currentTrack!)}\n\n` +
-                    `${this.getDisplayRepeatMode(queue.repeatMode, 'success')}`
+                }**\n ${this.getDisplayTrackDurationAndUrl(queue.currentTrack!, translator)}\n\n` +
+                    `${this.getDisplayRepeatMode(queue.repeatMode, translator, 'success')}`
             )
             .setThumbnail(track.thumbnail)
             .setColor(this.embedOptions.colors.success);

--- a/src/interactions/components/action-previous-button.ts
+++ b/src/interactions/components/action-previous-button.ts
@@ -30,11 +30,11 @@ class ActionPreviousButton extends BaseComponentInteraction {
         ]);
 
         if (!queue || (queue.tracks.data.length === 0 && !queue.currentTrack)) {
-            return await this.handleNoQueue(interaction);
+            return await this.handleNoQueue(interaction, translator);
         }
 
         if (queue.currentTrack!.id !== referenceId) {
-            return await this.handleAlreadySkipped(interaction);
+            return await this.handleAlreadySkipped(interaction, translator);
         }
 
         return await this.handleBackToPreviousTrack(logger, interaction, history, translator);
@@ -76,12 +76,15 @@ class ActionPreviousButton extends BaseComponentInteraction {
         });
     }
 
-    private async handleNoQueue(interaction: MessageComponentInteraction) {
+    private async handleNoQueue(interaction: MessageComponentInteraction, translator: TFunction) {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\nThere is nothing currently playing. First add some tracks with **\`/play\`**!`
+                        translator('validation.queueNoCurrentTrack', {
+                            icon: this.embedOptions.icons.warning,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ],
@@ -89,12 +92,14 @@ class ActionPreviousButton extends BaseComponentInteraction {
         });
     }
 
-    private async handleAlreadySkipped(interaction: MessageComponentInteraction) {
+    private async handleAlreadySkipped(interaction: MessageComponentInteraction, translator: TFunction) {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\nThis track has already been skipped or is no longer playing.`
+                        translator('validation.trackNotPlayingAnymore', {
+                            icon: this.embedOptions.icons.warning
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ],
@@ -110,8 +115,10 @@ class ActionPreviousButton extends BaseComponentInteraction {
         const successEmbed = new EmbedBuilder()
             .setAuthor(this.getEmbedUserAuthor(interaction))
             .setDescription(
-                `**${this.embedOptions.icons.back} Recovered track**\n` +
-                    `${this.getDisplayTrackDurationAndUrl(recoveredTrack, translator)}`
+                translator('commands.back.trackRecovered', {
+                    icon: this.embedOptions.icons.back,
+                    track: this.getDisplayTrackDurationAndUrl(recoveredTrack, translator)
+                })
             )
             .setThumbnail(recoveredTrack.thumbnail)
             .setColor(this.embedOptions.colors.success);

--- a/src/interactions/components/action-skip-button.ts
+++ b/src/interactions/components/action-skip-button.ts
@@ -6,6 +6,7 @@ import { checkQueueCurrentTrack, checkQueueExists } from '../../utils/validation
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../utils/validation/voiceChannelValidator';
 import { TFunction } from 'i18next';
 import { useServerTranslator } from '../../common/localeUtil';
+import { formatRepeatModeDetailed } from '../../common/formattingUtils';
 
 class ActionSkipButton extends BaseComponentInteraction {
     constructor() {
@@ -79,7 +80,7 @@ class ActionSkipButton extends BaseComponentInteraction {
             .setDescription(
                 `**${this.embedOptions.icons.skipped} Skipped track**\n` +
                     `${this.getDisplayTrackDurationAndUrl(skippedTrack, translator)}\n\n` +
-                    `${this.getDisplayRepeatMode(queue.repeatMode, translator, 'success')}`
+                    `${formatRepeatModeDetailed(queue.repeatMode, this.embedOptions, translator, 'success')}`
             )
             .setThumbnail(skippedTrack.thumbnail)
             .setColor(this.embedOptions.colors.success);

--- a/src/interactions/components/action-skip-button.ts
+++ b/src/interactions/components/action-skip-button.ts
@@ -4,6 +4,8 @@ import { BaseComponentInteraction } from '../../classes/interactions';
 import { BaseComponentParams, BaseComponentReturnType } from '../../types/interactionTypes';
 import { checkQueueCurrentTrack, checkQueueExists } from '../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../utils/validation/voiceChannelValidator';
+import { TFunction } from 'i18next';
+import { useServerTranslator } from '../../common/localeUtil';
 
 class ActionSkipButton extends BaseComponentInteraction {
     constructor() {
@@ -13,6 +15,7 @@ class ActionSkipButton extends BaseComponentInteraction {
     async execute(params: BaseComponentParams): BaseComponentReturnType {
         const { executionId, interaction, referenceId } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -36,7 +39,7 @@ class ActionSkipButton extends BaseComponentInteraction {
         logger.debug('Skipped the track.');
 
         logger.debug('Responding with success embed.');
-        return await this.handleSuccess(interaction, skippedTrack, queue);
+        return await this.handleSuccess(interaction, skippedTrack, queue, translator);
     }
 
     private async handleNoQueue(interaction: MessageComponentInteraction) {
@@ -65,13 +68,18 @@ class ActionSkipButton extends BaseComponentInteraction {
         });
     }
 
-    private async handleSuccess(interaction: MessageComponentInteraction, skippedTrack: Track, queue: GuildQueue) {
+    private async handleSuccess(
+        interaction: MessageComponentInteraction,
+        skippedTrack: Track,
+        queue: GuildQueue,
+        translator: TFunction
+    ) {
         const successEmbed = new EmbedBuilder()
             .setAuthor(this.getEmbedUserAuthor(interaction))
             .setDescription(
                 `**${this.embedOptions.icons.skipped} Skipped track**\n` +
-                    `${this.getDisplayTrackDurationAndUrl(skippedTrack)}\n\n` +
-                    `${this.getDisplayRepeatMode(queue.repeatMode, 'success')}`
+                    `${this.getDisplayTrackDurationAndUrl(skippedTrack, translator)}\n\n` +
+                    `${this.getDisplayRepeatMode(queue.repeatMode, translator, 'success')}`
             )
             .setThumbnail(skippedTrack.thumbnail)
             .setColor(this.embedOptions.colors.success);

--- a/src/interactions/components/action-skip-button.ts
+++ b/src/interactions/components/action-skip-button.ts
@@ -6,7 +6,7 @@ import { checkQueueCurrentTrack, checkQueueExists } from '../../utils/validation
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../utils/validation/voiceChannelValidator';
 import { TFunction } from 'i18next';
 import { useServerTranslator } from '../../common/localeUtil';
-import { formatRepeatModeDetailed } from '../../common/formattingUtils';
+import { formatRepeatModeDetailed, formatSlashCommand } from '../../common/formattingUtils';
 
 class ActionSkipButton extends BaseComponentInteraction {
     constructor() {
@@ -28,11 +28,11 @@ class ActionSkipButton extends BaseComponentInteraction {
         ]);
 
         if (!queue || (queue.tracks.data.length === 0 && !queue.currentTrack)) {
-            return await this.handleNoQueue(interaction);
+            return await this.handleNoQueue(interaction, translator);
         }
 
         if (queue.currentTrack!.id !== referenceId) {
-            return await this.handleAlreadySkipped(interaction);
+            return await this.handleAlreadySkipped(interaction, translator);
         }
 
         const skippedTrack: Track = queue.currentTrack!;
@@ -43,12 +43,15 @@ class ActionSkipButton extends BaseComponentInteraction {
         return await this.handleSuccess(interaction, skippedTrack, queue, translator);
     }
 
-    private async handleNoQueue(interaction: MessageComponentInteraction) {
+    private async handleNoQueue(interaction: MessageComponentInteraction, translator: TFunction) {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\nThere is nothing currently playing. First add some tracks with **\`/play\`**!`
+                        translator('validation.queueNoCurrentTrack', {
+                            icon: this.embedOptions.icons.warning,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ],
@@ -56,12 +59,14 @@ class ActionSkipButton extends BaseComponentInteraction {
         });
     }
 
-    private async handleAlreadySkipped(interaction: MessageComponentInteraction) {
+    private async handleAlreadySkipped(interaction: MessageComponentInteraction, translator: TFunction) {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${this.embedOptions.icons.warning} Oops!**\nThis track has already been skipped or is no longer playing.`
+                        translator('validation.trackNotPlayingAnymore', {
+                            icon: this.embedOptions.icons.warning
+                        })
                     )
                     .setColor(this.embedOptions.colors.warning)
             ],
@@ -78,7 +83,10 @@ class ActionSkipButton extends BaseComponentInteraction {
         const successEmbed = new EmbedBuilder()
             .setAuthor(this.getEmbedUserAuthor(interaction))
             .setDescription(
-                `**${this.embedOptions.icons.skipped} Skipped track**\n` +
+                translator('commands.skip.skippedTrack', {
+                    icon: this.embedOptions.icons.skipped
+                }) +
+                    '\n' +
                     `${this.getDisplayTrackDurationAndUrl(skippedTrack, translator)}\n\n` +
                     `${formatRepeatModeDetailed(queue.repeatMode, this.embedOptions, translator, 'success')}`
             )

--- a/src/interactions/components/filters-disable-button.ts
+++ b/src/interactions/components/filters-disable-button.ts
@@ -5,6 +5,7 @@ import { BaseComponentInteraction } from '../../classes/interactions';
 import { BaseComponentParams, BaseComponentReturnType } from '../../types/interactionTypes';
 import { checkQueueExists } from '../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../utils/validation/voiceChannelValidator';
+import { useServerTranslator } from '../../common/localeUtil';
 
 class FiltersDisableButtonComponent extends BaseComponentInteraction {
     constructor() {
@@ -14,6 +15,7 @@ class FiltersDisableButtonComponent extends BaseComponentInteraction {
     async execute(params: BaseComponentParams): BaseComponentReturnType {
         const { executionId, interaction } = params;
         const logger = this.getLogger(this.name, executionId, interaction);
+        const translator = useServerTranslator(interaction);
 
         const queue: GuildQueue = useQueue(interaction.guild!.id)!;
 
@@ -31,8 +33,9 @@ class FiltersDisableButtonComponent extends BaseComponentInteraction {
                 new EmbedBuilder()
                     .setAuthor(this.getEmbedUserAuthor(interaction))
                     .setDescription(
-                        `**${this.embedOptions.icons.success} Disabled filters**\n` +
-                            'All audio filters have been disabled.'
+                        translator('commands.filters.allFiltersDisabled', {
+                            icon: this.embedOptions.icons.success
+                        })
                     )
                     .setColor(this.embedOptions.colors.success)
             ],

--- a/src/types/configTypes.d.ts
+++ b/src/types/configTypes.d.ts
@@ -63,6 +63,7 @@ export type EmbedOptions = {
         nextTrack: string;
         previousTrack: string;
         pauseResumeTrack: string;
+        paused: string;
         shuffleQueue: string;
         loop: string;
         loopAction: string;

--- a/src/utils/validation/permissionValidator.ts
+++ b/src/utils/validation/permissionValidator.ts
@@ -13,6 +13,7 @@ import { InteractionValidationError } from '../../classes/interactions';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
+import { useServerTranslator } from '../../common/localeUtil';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 export const checkVoicePermissionJoinAndTalk = async ({ interaction, executionId }: ValidatorParams) => {
@@ -23,6 +24,7 @@ export const checkVoicePermissionJoinAndTalk = async ({ interaction, executionId
         shardId: interaction.guild?.shardId,
         guildId: interaction.guild?.id
     });
+    const translator = useServerTranslator(interaction);
 
     const channel: VoiceBasedChannel | null =
         interaction.member instanceof GuildMember ? interaction.member.voice.channel : null;
@@ -34,7 +36,10 @@ export const checkVoicePermissionJoinAndTalk = async ({ interaction, executionId
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Oops!**\nI do not have permission to play audio in the voice channel <#${channel.id}>.\n\nPlease make sure I have the **\`Connect\`** and **\`Speak\`** permissions in this voice channel.`
+                        translator('validation.cannotJoinVoiceOrTalk', {
+                            icon: embedOptions.icons.warning,
+                            channel: `<#${channel.id}>`
+                        })
                     )
                     .setColor(embedOptions.colors.warning)
                     .setFooter({
@@ -64,6 +69,7 @@ export const checkChannelPermissionViewable = async ({ interaction, executionId 
         shardId: interaction.guild?.shardId,
         guildId: interaction.guild?.id
     });
+    const translator = useServerTranslator(interaction);
 
     const channel: TextBasedChannel | null = interaction.channel;
 
@@ -89,7 +95,10 @@ export const checkChannelPermissionViewable = async ({ interaction, executionId 
                     embeds: [
                         new EmbedBuilder()
                             .setDescription(
-                                `**${embedOptions.icons.warning} Oops!**\nI do not have permission to send message replies in the channel <#${channel.id}>.\n\nPlease make sure I have the **\`View Channel\`** permission in this text channel.`
+                                translator('validation.cannotSendMessageInChannel', {
+                                    icon: embedOptions.icons.warning,
+                                    channel: `<#${channel.id}>`
+                                })
                             )
                             .setColor(embedOptions.colors.warning)
                             .setFooter({

--- a/src/utils/validation/queueValidator.ts
+++ b/src/utils/validation/queueValidator.ts
@@ -5,6 +5,8 @@ import { InteractionValidationError } from '../../classes/interactions';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
+import { useServerTranslator } from '../../common/localeUtil';
+import { formatSlashCommand } from '../../common/formattingUtils';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 export const checkQueueExists = async ({ interaction, queue, executionId }: ValidatorParams) => {
@@ -15,6 +17,7 @@ export const checkQueueExists = async ({ interaction, queue, executionId }: Vali
         shardId: interaction.guild?.shardId,
         guildId: interaction.guild?.id
     });
+    const translator = useServerTranslator(interaction);
 
     const interactionIdentifier =
         interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId;
@@ -24,7 +27,10 @@ export const checkQueueExists = async ({ interaction, queue, executionId }: Vali
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Oops!**\nThere are no tracks in the queue and nothing currently playing. First add some tracks with **\`/play\`**!`
+                        translator('validation.queueDoesNotExist', {
+                            icon: embedOptions.icons.warning,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(embedOptions.colors.warning)
                     .setFooter({
@@ -52,6 +58,7 @@ export const checkHistoryExists = async ({ interaction, history, executionId }: 
         shardId: interaction.guild?.shardId,
         guildId: interaction.guild?.id
     });
+    const translator = useServerTranslator(interaction);
 
     const interactionIdentifier =
         interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId;
@@ -61,7 +68,10 @@ export const checkHistoryExists = async ({ interaction, history, executionId }: 
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Oops!**\nThere are no tracks in the history and nothing currently playing. First add some tracks with **\`/play\`**!`
+                        translator('validation.historyDoesNotExist', {
+                            icon: embedOptions.icons.warning,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(embedOptions.colors.warning)
                     .setFooter({
@@ -89,6 +99,7 @@ export const checkQueueCurrentTrack = async ({ interaction, queue, executionId }
         shardId: interaction.guild?.shardId,
         guildId: interaction.guild?.id
     });
+    const translator = useServerTranslator(interaction);
 
     const interactionIdentifier =
         interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId;
@@ -98,7 +109,10 @@ export const checkQueueCurrentTrack = async ({ interaction, queue, executionId }
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Oops!**\nThere is nothing currently playing. First add some tracks with **\`/play\`**!`
+                        translator('validation.queueNoCurrentTrack', {
+                            icon: embedOptions.icons.warning,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(embedOptions.colors.warning)
                     .setFooter({
@@ -126,6 +140,7 @@ export const checkQueueEmpty = async ({ interaction, queue, executionId }: Valid
         shardId: interaction.guild?.shardId,
         guildId: interaction.guild?.id
     });
+    const translator = useServerTranslator(interaction);
 
     const interactionIdentifier =
         interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId;
@@ -135,7 +150,10 @@ export const checkQueueEmpty = async ({ interaction, queue, executionId }: Valid
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Oops!**\nThere are no tracks added to the queue. First add some tracks with **\`/play\`**!`
+                        translator('validation.queueIsEmpty', {
+                            icon: embedOptions.icons.warning,
+                            playCommand: formatSlashCommand('play', translator)
+                        })
                     )
                     .setColor(embedOptions.colors.warning)
                     .setFooter({

--- a/src/utils/validation/systemCommandValidator.ts
+++ b/src/utils/validation/systemCommandValidator.ts
@@ -5,6 +5,8 @@ import { InteractionValidationError } from '../../classes/interactions';
 import loggerModule from '../../services/logger';
 import { EmbedOptions, SystemOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
+import { useServerTranslator } from '../../common/localeUtil';
+import { formatSlashCommand } from '../../common/formattingUtils';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const systemOptions: SystemOptions = config.get('systemOptions');
@@ -16,6 +18,7 @@ export const checkValidGuildId = async ({ interaction, executionId }: ValidatorP
         shardId: interaction.guild?.shardId,
         guildId: interaction.guild?.id
     });
+    const translator = useServerTranslator(interaction);
 
     const interactionIdentifier =
         interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId;
@@ -25,7 +28,10 @@ export const checkValidGuildId = async ({ interaction, executionId }: ValidatorP
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Oops!**\nNo permission to perform this action.\n\nThe command **\`/${interactionIdentifier}\`** cannot be executed in this server.`
+                        translator('validation.notValidGuildId', {
+                            icon: embedOptions.icons.warning,
+                            command: formatSlashCommand(interactionIdentifier, translator)
+                        })
                     )
                     .setColor(embedOptions.colors.warning)
             ]

--- a/src/utils/validation/voiceChannelValidator.ts
+++ b/src/utils/validation/voiceChannelValidator.ts
@@ -5,6 +5,7 @@ import { InteractionValidationError } from '../../classes/interactions';
 import loggerModule from '../../services/logger';
 import { EmbedOptions } from '../../types/configTypes';
 import { ValidatorParams } from '../../types/utilTypes';
+import { useServerTranslator } from '../../common/localeUtil';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 export const checkInVoiceChannel = async ({ interaction, executionId }: ValidatorParams) => {
@@ -15,6 +16,7 @@ export const checkInVoiceChannel = async ({ interaction, executionId }: Validato
         shardId: interaction.guild?.shardId,
         guildId: interaction.guild?.id
     });
+    const translator = useServerTranslator(interaction);
 
     const interactionIdentifier =
         interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId;
@@ -24,7 +26,9 @@ export const checkInVoiceChannel = async ({ interaction, executionId }: Validato
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Not in a voice channel**\nYou need to be in a voice channel to perform this action.`
+                        translator('validation.notInVoiceChannel', {
+                            icon: embedOptions.icons.warning
+                        })
                     )
                     .setColor(embedOptions.colors.warning)
                     .setFooter({
@@ -49,6 +53,7 @@ export const checkSameVoiceChannel = async ({ interaction, queue, executionId }:
         shardId: interaction.guild?.shardId,
         guildId: interaction.guild?.id
     });
+    const translator = useServerTranslator(interaction);
 
     const interactionIdentifier =
         interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId;
@@ -66,7 +71,10 @@ export const checkSameVoiceChannel = async ({ interaction, queue, executionId }:
             embeds: [
                 new EmbedBuilder()
                     .setDescription(
-                        `**${embedOptions.icons.warning} Not in same voice channel**\nYou need to be in the same voice channel as me to perform this action.\n\n**Voice channel:** <#${queue.dispatcher.channel.id}>`
+                        translator('validation.notInSameVoiceChannel', {
+                            icon: embedOptions.icons.warning,
+                            channel: `<#${queue.dispatcher.channel.id}>`
+                        })
                     )
                     .setColor(embedOptions.colors.warning)
                     .setFooter({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true
     },
-    "include": ["src/**/*.ts"],
+    "include": ["src/**/*.ts", "locales/**/*.ts"],
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Changes
Adds support for localization using the `i18next` library.

### Dependencies
- `i18next` Localization library
- `i18next-fs-backend` Loading localization files
- `i18next-resources-for-ts` Typesafety for localization
Didn't commit `package-lock` because that should only be generated by the maintainer.

## Todo
- [X] ~~Automatically apply Discord native localization to slash commands~~ Done using `localizeCommand` on the `SlashCommandBuilder`
- [X] ~~Full typesafety for using the localization function~~ Need to `npm run toc` on every new key added for types to generate
- [X] ~~Add support for client versus server side language preference~~ Using `useServerTranslator`/`useUserTranslator`
- [X] ~~Move all free-standing strings to the translation file~~
- [X] ~~Merge similar/reused strings~~
- [ ] Finish TODOs (localizing option names, adding subcommands)
- [ ] Test using different server and client settings