### PR TITLE
Subcommand localization

### DIFF
--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -220,6 +220,54 @@
             "unableToReload": "{{icon}} **Oops!**\n_Hmm..._ It seems I am unable to reload the interaction module across shards."
         },
         "remove": {
+            "metadata": {
+                "name": "remove",
+                "description": "Remove tracks from the queue using certain filters.",
+                "options": {
+                    "track": {
+                        "name": "track",
+                        "description": "Remove a track from the queue by position.",
+                        "options": {
+                            "position": {
+                                "name": "position",
+                                "description": "The position in queue for the track to remove."
+                            }
+                        }
+                    },
+                    "range": {
+                        "name": "range",
+                        "description": "Remove a range of tracks from the queue.",
+                        "options": {
+                            "start": {
+                                "name": "start",
+                                "description": "The starting position of the range to remove."
+                            },
+                            "end": {
+                                "name": "end",
+                                "description": "The ending position of the range to remove."
+                            }
+                        }
+                    },
+                    "queue": {
+                        "name": "queue",
+                        "description": "Remove all tracks from the queue."
+                    },
+                    "user": {
+                        "name": "user",
+                        "description": "Remove all tracks added by a specific user.",
+                        "options": {
+                            "target": {
+                                "name": "target",
+                                "description": "User whose tracks to remove."
+                            }
+                        }
+                    },
+                    "duplicates": {
+                        "name": "duplicates",
+                        "description": "Remove all duplicate tracks from the queue."
+                    }
+                }
+            },
             "noTracksRemoved": "{{icon}} **No tracks removed**\nThere were no tracks removed from the queue. Please check if the option you selected has tracks to remove.",
             "removedTrack": "{{icon}} **Removed track**",
             "removedTracks": "{{icon}} **Removed tracks**\n**`{{count}}`** tracks were removed from the queue.",

--- a/src/common/localeUtil.ts
+++ b/src/common/localeUtil.ts
@@ -180,7 +180,5 @@ export function localizeCommand(
         }
     }
 
-    // if ((jsonCommand  as ReturnType<SlashCommandSubcommandsOnlyBuilder["toJSON"]>).options.)
-
     return jsonCommand as SlashCommandBuilder;
 }

--- a/src/interactions/commands/player/remove.ts
+++ b/src/interactions/commands/player/remove.ts
@@ -6,60 +6,31 @@ import { checkQueueExists } from '../../../utils/validation/queueValidator';
 import { checkInVoiceChannel, checkSameVoiceChannel } from '../../../utils/validation/voiceChannelValidator';
 import { Logger } from 'pino';
 import { TFunction } from 'i18next';
-import { useServerTranslator } from '../../../common/localeUtil';
+import { localizeCommand, useServerTranslator } from '../../../common/localeUtil';
 import { formatSlashCommand } from '../../../common/formattingUtils';
 
 class RemoveCommand extends BaseSlashCommandInteraction {
     constructor() {
-        // TODO: Add subcommand localization support
-        const data = new SlashCommandBuilder()
-            .setName('remove')
-            .setDescription('Remove tracks from the queue')
-            .addSubcommand((subcommand) =>
-                subcommand
-                    .setName('track')
-                    .setDescription('Remove a track from the queue by position')
-                    .addIntegerOption((option) =>
-                        option
-                            .setName('position')
-                            .setDescription('The position in queue for track to remove.')
-                            .setMinValue(1)
-                            .setRequired(true)
-                    )
-            )
-            .addSubcommand((subcommand) =>
-                subcommand
-                    .setName('range')
-                    .setDescription('Remove a range of tracks from the queue')
-                    .addIntegerOption((option) =>
-                        option
-                            .setName('start')
-                            .setDescription('The starting position of the range to remove')
-                            .setMinValue(1)
-                            .setRequired(true)
-                    )
-                    .addIntegerOption((option) =>
-                        option
-                            .setName('end')
-                            .setDescription('The ending position of the range to remove')
-                            .setMinValue(1)
-                            .setRequired(true)
-                    )
-            )
-            .addSubcommand((subcommand) =>
-                subcommand.setName('queue').setDescription('Remove all tracks from the queue')
-            )
-            .addSubcommand((subcommand) =>
-                subcommand
-                    .setName('user')
-                    .setDescription('Remove all tracks from a specific user')
-                    .addUserOption((option) =>
-                        option.setName('target').setDescription('User to remove tracks for').setRequired(true)
-                    )
-            )
-            .addSubcommand((subcommand) =>
-                subcommand.setName('duplicates').setDescription('Remove all duplicate tracks from the queue')
-            );
+        const data = localizeCommand(
+            new SlashCommandBuilder()
+                .setName('remove')
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('track')
+                        .addIntegerOption((option) => option.setName('position').setMinValue(1).setRequired(true))
+                )
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('range')
+                        .addIntegerOption((option) => option.setName('start').setMinValue(1).setRequired(true))
+                        .addIntegerOption((option) => option.setName('end').setMinValue(1).setRequired(true))
+                )
+                .addSubcommand((subcommand) => subcommand.setName('queue'))
+                .addSubcommand((subcommand) =>
+                    subcommand.setName('user').addUserOption((option) => option.setName('target').setRequired(true))
+                )
+                .addSubcommand((subcommand) => subcommand.setName('duplicates'))
+        );
         super(data);
     }
 


### PR DESCRIPTION
## Changes
Adds support for subcommand localization (but not subcommand groups). The subcommand keys are in `"options"`, just like in the `"remove"` command.