### PR TITLE
More translations

### DIFF
--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -458,6 +458,15 @@
     },
     "errors": {
         "unexpectedError": "**{{icon}} Uh-oh... _Something_ went wrong!**\nThere was an unexpected error while trying to perform this action. You can try again.\n\n_If this problem persists, please submit a bug report in the **[support server]({{serverInviteUrl}})**._",
-        "footerExecutionId": "Execution ID: {{executionId}}"
+        "footerExecutionId": "Execution ID: {{executionId}}",
+        "cannotExtractAudioStream": "**{{icon}} Oops!**\nUnable to retrieve audio for the track **[{{trackTitle}}]({{trackUrl}})**.\n\nIt seems that the source is not available publicly, or the source is not supported.",
+        "cannotLoadAudioStream": "**{{icon}} Uh-oh... _Something_ went wrong!**\nIt seems there was an issue while loading stream for the track.\n\nIf you performed a command, you can try again.\n\n_If this problem persists, please submit a bug report in the **[support server]({{serverInviteUrl}})**._",
+        "cannotPlayAudioStream": "**{{icon}} Uh-oh... _Something_ went wrong!**\nIt seems there was an issue while streaming the track.\n\nIf you performed a command, you can try again.\n\n_If this problem persists, please submit a bug report in the **[support server]({{serverInviteUrl}})**._",
+        "generalPlayerError": "**{{icon}} Uh-oh... _Something_ went wrong!**\nIt seems there was an issue related to the queue or current track.\n\nIf you performed a command, you can try again.\n\n_If this problem persists, please submit a bug report in the **[support server]({{serverInviteUrl}})**._"
+    },
+    "systemMessages": {
+        "playerSkipError": "{{icon}} **player.events.on('playerSkip')**\nTrack URL: {{trackUrl}}\n\n<@{{userId}}>",
+        "playerError": "{{icon}} **player.events.on('playerError')**\nMessage: {{message}}\n\n<@{{userId}}>",
+        "generalPlayerError": "{{icon}} **player.events.on('error')**\nMessage: {{message}}\n\n<@{{userId}}>"
     }
 }

--- a/locales/en/bot.json
+++ b/locales/en/bot.json
@@ -455,5 +455,9 @@
         "queueIsEmpty": "{{icon}} **Oops!\nThere are no tracks added to the queue. First add some tracks with {{playCommand}}!",
         "queueNoCurrentTrack": "{{icon}} **Oops!**\nThere is nothing currently playing. First add some tracks with {{playCommand}}!",
         "trackNotPlayingAnymore": "{{icon}} **Oops!**\nThis track has been skipped or is no longer playing."
+    },
+    "errors": {
+        "unexpectedError": "**{{icon}} Uh-oh... _Something_ went wrong!**\nThere was an unexpected error while trying to perform this action. You can try again.\n\n_If this problem persists, please submit a bug report in the **[support server]({{serverInviteUrl}})**._",
+        "footerExecutionId": "Execution ID: {{executionId}}"
     }
 }

--- a/locales/no/bot.json
+++ b/locales/no/bot.json
@@ -455,5 +455,9 @@
         "queueIsEmpty": "{{icon}} **Oi sann!\nDet er ingen låter lagt til i køen. Legg først til noen låter med {{playCommand}}!",
         "queueNoCurrentTrack": "{{icon}} **Oi sann!**\nDet spilles ingenting av for øyeblikket. Legg først til noen låter med {{playCommand}}!",
         "trackNotPlayingAnymore": "{{icon}} **Oi sann!**\nDenne låten har blitt hoppet over allerede eller spiller ikke lenger."
+    },
+    "errors": {
+        "unexpectedError": "**{{icon}} Å nei... _Noe_ gikk galt!**\nDet oppstod en uventet feil under denne handlingen. Du kan forsøke igjen.\n\n_Hvis dette problemet vedvarer, vennligst send inn en feilrapport i **[støtteserveren]({{serverInviteUrl}})**._",
+        "footerExecutionId": "Referanse ID: {{executionId}}"
     }
 }

--- a/locales/no/bot.json
+++ b/locales/no/bot.json
@@ -458,6 +458,15 @@
     },
     "errors": {
         "unexpectedError": "**{{icon}} Å nei... _Noe_ gikk galt!**\nDet oppstod en uventet feil under denne handlingen. Du kan forsøke igjen.\n\n_Hvis dette problemet vedvarer, vennligst send inn en feilrapport i **[støtteserveren]({{serverInviteUrl}})**._",
-        "footerExecutionId": "Referanse ID: {{executionId}}"
+        "footerExecutionId": "Referanse ID: {{executionId}}",
+        "cannotExtractAudioStream": "**{{icon}} Oi sann!**\nKan ikke hente lyd for låten **[{{trackTitle}}]({{trackUrl}})**.\n\nDet ser ut til at kilden ikke er offentlig tilgjengelig, eller at kilden ikke støttes.",
+        "cannotLoadAudioStream": "**{{icon}} Å nei... _Noe_ gikk galt!**\nDet ser ut til at det var et problem med å laste lyd for låten.\n\nHvis du utførte en kommando, kan du prøve igjen.\n\n_Hvis dette problemet vedvarer, vennligst send inn en feilrapport i **[støtteserveren]({{serverInviteUrl}})**._",
+        "cannotPlayAudioStream": "**{{icon}} Å nei... _Noe_ gikk galt!**\nDet ser ut til at det var et problem med å spille av lyd for låten.\n\nHvis du utførte en kommando, kan du prøve igjen.\n\n_Hvis dette problemet vedvarer, vennligst send inn en feilrapport i **[støtteserveren]({{serverInviteUrl}})**._",
+        "generalPlayerError": "**{{icon}} Å nei... _Noe_ gikk galt!**\nDet ser ut til at det var et problem relatert til køen eller den nåværende låten.\n\nHvis du utførte en kommando, kan du prøve igjen.\n\n_Hvis dette problemet vedvarer, vennligst send inn en feilrapport i **[støtteserveren]({{serverInviteUrl}})**._"
+    },
+    "systemMessages": {
+        "playerSkipError": "{{icon}} **player.events.on('playerSkip')**\nURL til låt: {{trackUrl}}\n\n<@{{userId}}>",
+        "playerError": "{{icon}} **player.events.on('playerError')**\nMelding: {{message}}\n\n<@{{userId}}>",
+        "generalPlayerError": "{{icon}} **player.events.on('error')**\nMelding: {{message}}\n\n<@{{userId}}>"
     }
 }

--- a/locales/no/bot.json
+++ b/locales/no/bot.json
@@ -5,7 +5,7 @@
     "commands": {
         "back": {
             "metadata": {
-                "name": "back",
+                "name": "tilbake",
                 "description": "Gå tilbake til forrige låt eller angitt posisjon i historikken.",
                 "options": {
                     "position": {
@@ -21,7 +21,7 @@
         },
         "filters": {
             "metadata": {
-                "name": "filters",
+                "name": "filtre",
                 "description": "Velg mellom ulike lydfiltre.",
                 "options": {
                     "type": {
@@ -45,7 +45,7 @@
         },
         "guilds": {
             "metadata": {
-                "name": "guilds",
+                "name": "servere",
                 "description": "Vis de 25 største serverne etter medlemstall."
             },
             "topGuildsByMemberCount": "{{icon}} **Topp {{count}} servere etter medlemstall ({{totalCount}} totalt)**",
@@ -53,7 +53,7 @@
         },
         "help": {
             "metadata": {
-                "name": "help",
+                "name": "hjelp",
                 "description": "Vis listen over bot-kommandoer."
             },
             "addBotButton": "Legg til bot",
@@ -62,7 +62,7 @@
         },
         "history": {
             "metadata": {
-                "name": "history",
+                "name": "historikk",
                 "description": "Vis historikk over låter som har blitt spilt.",
                 "options": {
                     "page": {
@@ -78,7 +78,7 @@
         },
         "join": {
             "metadata": {
-                "name": "join",
+                "name": "bli-med",
                 "description": "Botten vil bli med i talekanalen hvis den ikke allerede er i en."
             },
             "alreadyConnected": "{{icon}} **Oi sann!**\nJeg er allerede koblet til talekanalen {{channel}}.\n\nFor å koble meg fra kanalen, bruk kommandoen {{leaveCommand}}.",
@@ -87,14 +87,14 @@
         },
         "leave": {
             "metadata": {
-                "name": "leave",
+                "name": "forlat",
                 "description": "Tøm køen og fjern botten fra talekanalen."
             },
             "leavingChannel": "{{icon}} **Koblet fra kanal**\nTømte låtkøen og koblet fra talekanalen.\n\nFor å spille mer musikk, bruk kommandoen {{playCommand}}!"
         },
         "loop": {
             "metadata": {
-                "name": "loop",
+                "name": "repeter",
                 "description": "Velg mellom å spille en låt på reptisjon, hele køen eller autoplay.",
                 "options": {
                     "mode": {
@@ -118,7 +118,7 @@
         },
         "lyrics": {
             "metadata": {
-                "name": "lyrics",
+                "name": "sangtekst",
                 "description": "Søk etter Genius sangtekster for nåværende eller angitt låt.",
                 "options": {
                     "query": {
@@ -133,7 +133,7 @@
         },
         "move": {
             "metadata": {
-                "name": "move",
+                "name": "flytt",
                 "description": "Flytt en låt til en spesifisert posisjon i køen.",
                 "options": {
                     "from": {
@@ -152,7 +152,7 @@
         },
         "nowplaying": {
             "metadata": {
-                "name": "nowplaying",
+                "name": "spiller-nå",
                 "description": "Vis informasjon om nåværende låt."
             },
             "embedFields": {
@@ -176,11 +176,11 @@
         },
         "play": {
             "metadata": {
-                "name": "play",
-                "description": "Legg til en låt eller spilleliste i køen ved søkespørring eller URL.",
+                "name": "spill-av",
+                "description": "Legg til en låt eller spilleliste i køen ved søk eller URL.",
                 "options": {
                     "query": {
-                        "name": "spørring",
+                        "name": "søk",
                         "description": "Søkespørring ved tekst eller URL."
                     }
                 }
@@ -195,7 +195,7 @@
         },
         "queue": {
             "metadata": {
-                "name": "queue",
+                "name": "kø",
                 "description": "Vis låter som har blitt lagt til i køen.",
                 "options": {
                     "page": {
@@ -213,13 +213,61 @@
         },
         "reload": {
             "metadata": {
-                "name": "reload",
+                "name": "oppdater",
                 "description": "Last inn bot-kommandoer, autocompletion og component interaksjoner på nytt på tvers av shards."
             },
             "reloadedCommands": "{{icon}} **Kommandoer lastet inn på nytt**",
             "unableToReload": "{{icon}} **Oi sann!**\n_Hmm..._ Det ser ut til at jeg ikke klarer å laste inn interaksjoner og kommandoer på tvers av shards."
         },
         "remove": {
+            "metadata": {
+                "name": "fjern",
+                "description": "Fjern låter fra køen med bruk av forskjellige filtre.",
+                "options": {
+                    "track": {
+                        "name": "låt",
+                        "description": "Fjern en låt fra køen med å angi posisjon.",
+                        "options": {
+                            "position": {
+                                "name": "posisjon",
+                                "description": "Posisjonen i køen for låten som skal fjernes."
+                            }
+                        }
+                    },
+                    "range": {
+                        "name": "område",
+                        "description": "Fjern et utvalg av låter fra køen med å angi et område av posisjoner.",
+                        "options": {
+                            "start": {
+                                "name": "start",
+                                "description": "Startposisjonen for låtene som skal fjernes."
+                            },
+                            "end": {
+                                "name": "slutt",
+                                "description": "Sluttposisjonen for låtene som skal fjernes."
+                            }
+                        }
+                    },
+                    "queue": {
+                        "name": "kø",
+                        "description": "Fjern alle låtene fra køen."
+                    },
+                    "user": {
+                        "name": "user",
+                        "description": "Fjern alle låtene lagt til av en spesifikk bruker.",
+                        "options": {
+                            "target": {
+                                "name": "bruker",
+                                "description": "Brukeren å fjerne låter for."
+                            }
+                        }
+                    },
+                    "duplicates": {
+                        "name": "duplikater",
+                        "description": "Fjern alle duplikate låter fra køen."
+                    }
+                }
+            },
             "noTracksRemoved": "{{icon}} **Ingen låter fjernet**\nDet ble ikke fjernet noen låter fra køen. Vennligst sjekk om alternativet du valgte har låter som kan fjernes.",
             "removedTrack": "{{icon}} **Fjernet låt**",
             "removedTracks": "{{icon}} **Fjernet låter**\n**`{{count}}`** låter ble fjernet fra køen.",
@@ -229,7 +277,7 @@
         },
         "seek": {
             "metadata": {
-                "name": "seek",
+                "name": "spol",
                 "description": "Spol til tidsposisjon i nåværende låt.",
                 "options": {
                     "duration": {
@@ -269,14 +317,14 @@
         },
         "shuffle": {
             "metadata": {
-                "name": "shuffle",
-                "description": "Tilfeldig stokk om rekkefølgen til alle låter i køen."
+                "name": "stokk-om",
+                "description": "Tilfeldig stokk om rekkefølgen til låter i køen."
             },
             "shuffledTracks": "{{icon}} **Stokket om rekkefølge**\n**{{count}}** låter i køen har blitt stokket om.\n\nVis den nye kørekkefølgen med {{queueCommand}}."
         },
         "skip": {
             "metadata": {
-                "name": "skip",
+                "name": "hopp",
                 "description": "Hopp over låt til neste eller angitt posisjon i køen.",
                 "options": {
                     "position": {
@@ -299,7 +347,7 @@
         },
         "stop": {
             "metadata": {
-                "name": "stop",
+                "name": "stopp",
                 "description": "Tøm køen og slutt å spille lyd."
             },
             "stoppedPlaying": "{{icon}} **Stoppet å spille**\nStoppet å spille lyd og tømte køen.\n\nFor å spille mer musikk, bruk kommandoen {{playCommand}}!"
@@ -312,7 +360,7 @@
         },
         "volume": {
             "metadata": {
-                "name": "volume",
+                "name": "volum",
                 "description": "Vis eller endre avspillingsvolumet for låter.",
                 "options": {
                     "percentage": {

--- a/src/common/localeUtil.ts
+++ b/src/common/localeUtil.ts
@@ -4,6 +4,7 @@ import {
     ApplicationCommandOptionType,
     BaseInteraction,
     Locale,
+    LocaleString,
     SlashCommandBuilder,
     SlashCommandSubcommandBuilder,
     SlashCommandSubcommandsOnlyBuilder
@@ -34,11 +35,15 @@ translatorInstance.use(i18nextFsBackend).init<FsBackendOptions>({
 });
 
 export function useServerTranslator(interaction: BaseInteraction) {
-    return translatorInstance.getFixedT(interaction.guildLocale ?? 'en');
+    return translatorInstance.getFixedT(interaction.guildLocale ?? 'en-US');
 }
 
 export function useUserTranslator(interaction: BaseInteraction) {
-    return translatorInstance.getFixedT(interaction.locale ?? 'en');
+    return translatorInstance.getFixedT(interaction.locale ?? 'en-US');
+}
+
+export function useLanguageTranslator(language: LocaleString) {
+    return translatorInstance.getFixedT(language ?? 'en-US');
 }
 
 export const DISCORD_LOCALES = Object.values(Locale);

--- a/src/events/player/playerSkip.ts
+++ b/src/events/player/playerSkip.ts
@@ -49,7 +49,7 @@ module.exports = {
                                 translator('errors.cannotExtractAudioStream', {
                                     icon: embedOptions.icons.warning,
                                     trackTitle: track.title,
-                                    trackurl: track.url
+                                    trackUrl: track.url
                                 })
                             )
                             .setColor(embedOptions.colors.warning)

--- a/src/events/player/playerSkip.ts
+++ b/src/events/player/playerSkip.ts
@@ -6,6 +6,7 @@ import { Logger } from 'pino';
 import loggerModule from '../../services/logger';
 import { BotOptions, EmbedOptions, SystemOptions } from '../../types/configTypes';
 import { ExtendedGuildQueuePlayerNode } from '../../types/eventTypes';
+import { useLanguageTranslator } from '../../common/localeUtil';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const botOptions: BotOptions = config.get('botOptions');
@@ -31,6 +32,10 @@ module.exports = {
             guildId: queue.metadata?.channel.guild.id
         });
 
+        const language =
+            queue.metadata?.client.guilds.cache.get(queue.metadata?.channel.guild.id)?.preferredLocale ?? 'en-US';
+        const translator = useLanguageTranslator(language);
+
         logger.debug(`Track [${track.url}] skipped with reason: ${reason}\n${description}`);
 
         if (reason === TrackSkipReason.NoStream) {
@@ -41,9 +46,11 @@ module.exports = {
                     embeds: [
                         new EmbedBuilder()
                             .setDescription(
-                                `**${embedOptions.icons.warning} Oops!**\n` +
-                                    `Unable to retrieve audio for the track **[${track.title}](${track.url})**.\n\n` +
-                                    'It seems that the source is not available publicly, or the source is not supported.'
+                                translator('errors.cannotExtractAudioStream', {
+                                    icon: embedOptions.icons.warning,
+                                    trackTitle: track.title,
+                                    trackurl: track.url
+                                })
                             )
                             .setColor(embedOptions.colors.warning)
                     ]
@@ -54,26 +61,34 @@ module.exports = {
                 embeds: [
                     new EmbedBuilder()
                         .setDescription(
-                            `**${embedOptions.icons.error} Uh-oh... _Something_ went wrong!**\nIt seems there was an issue while loading stream for the track.\n\nIf you performed a command, you can try again.\n\n_If this problem persists, please submit a bug report in the **[support server](${botOptions.serverInviteUrl})**._`
+                            translator('errors.cannotLoadAudioStream', {
+                                icon: embedOptions.icons.error,
+                                serverInviteUrl: botOptions.serverInviteUrl
+                            })
                         )
                         .setColor(embedOptions.colors.error)
-                        .setFooter({ text: `Execution ID: ${executionId}` })
+                        .setFooter({ text: translator('errors.footerExecutionId', { executionId: executionId }) })
                 ]
             });
             if (systemOptions.systemMessageChannelId && systemOptions.systemUserId) {
-                const channel: BaseGuildTextChannel = (await queue.metadata?.client.channels.cache.get(
+                const channel: BaseGuildTextChannel = queue.metadata?.client.channels.cache.get(
                     systemOptions.systemMessageChannelId
-                )) as BaseGuildTextChannel;
+                ) as BaseGuildTextChannel;
                 if (channel) {
                     await channel.send({
                         embeds: [
                             new EmbedBuilder()
                                 .setDescription(
-                                    `${embedOptions.icons.error} **player.events.on('playerSkip')**\nExecution id: ${executionId}\n${track.url}` +
-                                        `\n\n<@${systemOptions.systemUserId}>`
+                                    translator('systemMessages.playerSkipError', {
+                                        icon: embedOptions.icons.error,
+                                        trackUrl: track.url,
+                                        userId: systemOptions.systemUserId
+                                    })
                                 )
                                 .setColor(embedOptions.colors.error)
-                                .setFooter({ text: `Execution ID: ${executionId}` })
+                                .setFooter({
+                                    text: translator('errors.footerExecutionId', { executionId: executionId })
+                                })
                         ]
                     });
                 }

--- a/src/handlers/interactionErrorHandler.ts
+++ b/src/handlers/interactionErrorHandler.ts
@@ -11,11 +11,11 @@ import { Logger } from 'pino';
 import { CustomError, InteractionValidationError } from '../classes/interactions';
 import loggerModule from '../services/logger';
 import { BotOptions, EmbedOptions } from '../types/configTypes';
+import { useServerTranslator } from '../common/localeUtil';
 
 const embedOptions: EmbedOptions = config.get('embedOptions');
 const botOptions: BotOptions = config.get('botOptions');
 
-// TODO: Update TS Type for handlError
 export const handleError = async (
     interaction: Interaction,
     error: CustomError,
@@ -27,6 +27,7 @@ export const handleError = async (
         name: 'interactionErrorHandler',
         executionId: executionId
     });
+    const translator = useServerTranslator(interaction);
 
     if (error instanceof InteractionValidationError || error.type === 'InteractionValidationError') {
         logger.debug(
@@ -35,15 +36,17 @@ export const handleError = async (
         return;
     }
 
-    // TODO: Extract replies for embeds
     const errorReply: InteractionReplyOptions = {
         embeds: [
             new EmbedBuilder()
                 .setDescription(
-                    `**${embedOptions.icons.error} Uh-oh... _Something_ went wrong!**\nThere was an unexpected error while trying to perform this action. You can try again.\n\n_If this problem persists, please submit a bug report in the **[support server](${botOptions.serverInviteUrl})**._`
+                    translator('errors.unexpectedError', {
+                        icon: embedOptions.icons.error,
+                        serverInviteUrl: botOptions.serverInviteUrl
+                    })
                 )
                 .setColor(embedOptions.colors.error)
-                .setFooter({ text: `Execution ID: ${executionId}` })
+                .setFooter({ text: translator('errors.footerExecutionId', { executionId: executionId }) })
         ]
     };
 

--- a/src/interactions/commands/info/help.ts
+++ b/src/interactions/commands/info/help.ts
@@ -102,7 +102,7 @@ class HelpCommand extends BaseSlashCommandInteraction {
     private getCommandString(command: BaseSlashCommandInteraction, interaction: ChatInputCommandInteraction): string {
         const commandName = command.data.name;
         const metadataKey = `commands.${commandName}.metadata`;
-        const locale = interaction.guildLocale ?? 'en';
+        const locale = interaction.guildLocale ?? 'en-US';
         let translatedData: CommandMetadata | undefined = undefined;
         translatedData = translatorInstance.getResource(locale, 'bot', metadataKey) as CommandMetadata | undefined;
 
@@ -122,7 +122,7 @@ class HelpCommand extends BaseSlashCommandInteraction {
 
         if (option instanceof SlashCommandNumberOption || option instanceof SlashCommandStringOption) {
             const metadataKey = `commands.${commandName}.metadata.options.${option.name}`;
-            const locale = interaction.guildLocale ?? 'en';
+            const locale = interaction.guildLocale ?? 'en-US';
             let translatedData: CommandMetadata | undefined = undefined;
             translatedData = translatorInstance.getResource(locale, 'bot', metadataKey) as CommandMetadata | undefined;
             return `**\`${translatedData?.name ?? option.name}\`** `;

--- a/src/interactions/commands/info/help.ts
+++ b/src/interactions/commands/info/help.ts
@@ -106,7 +106,7 @@ class HelpCommand extends BaseSlashCommandInteraction {
         let translatedData: CommandMetadata | undefined = undefined;
         translatedData = translatorInstance.getResource(locale, 'bot', metadataKey) as CommandMetadata | undefined;
 
-        const commandParams: string = this.getCommandParams(command);
+        const commandParams: string = this.getCommandParams(command, interaction);
 
         const beta: string = command.isBeta ? `${this.embedOptions.icons.beta} ` : '';
         const newCommand: string = command.isNew ? `${this.embedOptions.icons.new} ` : '';
@@ -116,11 +116,18 @@ class HelpCommand extends BaseSlashCommandInteraction {
         }`;
     }
 
-    private getCommandParams(command: BaseSlashCommandInteraction): string {
+    private getCommandParams(command: BaseSlashCommandInteraction, interaction: ChatInputCommandInteraction): string {
+        const commandName = command.data.name;
         const option = command.data.options[0];
+
         if (option instanceof SlashCommandNumberOption || option instanceof SlashCommandStringOption) {
-            return `**\`${option.name}\`** `;
+            const metadataKey = `commands.${commandName}.metadata.options.${option.name}`;
+            const locale = interaction.guildLocale ?? 'en';
+            let translatedData: CommandMetadata | undefined = undefined;
+            translatedData = translatorInstance.getResource(locale, 'bot', metadataKey) as CommandMetadata | undefined;
+            return `**\`${translatedData?.name ?? option.name}\`** `;
         }
+
         return '';
     }
 }

--- a/src/interactions/commands/info/help.ts
+++ b/src/interactions/commands/info/help.ts
@@ -7,6 +7,7 @@ import {
     ChatInputCommandInteraction,
     Collection,
     ComponentType,
+    LocaleString,
     EmbedBuilder,
     SlashCommandBuilder,
     SlashCommandNumberOption,
@@ -91,22 +92,22 @@ class HelpCommand extends BaseSlashCommandInteraction {
     ): Promise<string> {
         const commandCollection = this.getNonSystemCommands(client!);
 
+        const locale = interaction.guildLocale ?? 'en-US';
         const commandStringList = commandCollection.map((command: BaseSlashCommandInteraction) => {
-            return this.getCommandString(command, interaction);
+            return this.getCommandString(command, locale);
         });
 
         const commandString = commandStringList.join('\n');
         return commandString;
     }
 
-    private getCommandString(command: BaseSlashCommandInteraction, interaction: ChatInputCommandInteraction): string {
+    private getCommandString(command: BaseSlashCommandInteraction, locale: LocaleString): string {
         const commandName = command.data.name;
         const metadataKey = `commands.${commandName}.metadata`;
-        const locale = interaction.guildLocale ?? 'en-US';
         let translatedData: CommandMetadata | undefined = undefined;
         translatedData = translatorInstance.getResource(locale, 'bot', metadataKey) as CommandMetadata | undefined;
 
-        const commandParams: string = this.getCommandParams(command, interaction);
+        const commandParams: string = this.getCommandParams(command, locale);
 
         const beta: string = command.isBeta ? `${this.embedOptions.icons.beta} ` : '';
         const newCommand: string = command.isNew ? `${this.embedOptions.icons.new} ` : '';
@@ -116,13 +117,12 @@ class HelpCommand extends BaseSlashCommandInteraction {
         }`;
     }
 
-    private getCommandParams(command: BaseSlashCommandInteraction, interaction: ChatInputCommandInteraction): string {
+    private getCommandParams(command: BaseSlashCommandInteraction, locale: LocaleString): string {
         const commandName = command.data.name;
         const option = command.data.options[0];
 
         if (option instanceof SlashCommandNumberOption || option instanceof SlashCommandStringOption) {
             const metadataKey = `commands.${commandName}.metadata.options.${option.name}`;
-            const locale = interaction.guildLocale ?? 'en-US';
             let translatedData: CommandMetadata | undefined = undefined;
             translatedData = translatorInstance.getResource(locale, 'bot', metadataKey) as CommandMetadata | undefined;
             return `**\`${translatedData?.name ?? option.name}\`** `;

--- a/src/interactions/commands/system/systemstatus.ts
+++ b/src/interactions/commands/system/systemstatus.ts
@@ -33,7 +33,11 @@ class SystemStatusCommand extends BaseSlashCommandInteraction {
         return await interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setDescription(`**${this.embedOptions.icons.bot} Bot status**\n` + botStatisticsEmbedString)
+                    .setDescription(
+                        translator('statistics.botStatus.title', { icon: this.embedOptions.icons.bot }) +
+                            '\n' +
+                            botStatisticsEmbedString
+                    )
                     .addFields(
                         {
                             name: translator('statistics.queueStatus.title', {

--- a/src/tests/help.test.ts
+++ b/src/tests/help.test.ts
@@ -16,7 +16,8 @@ describe('HelpCommand', () => {
                 }
             } as unknown as BaseSlashCommandInteraction;
 
-            const commandParams = helpCommand['getCommandParams'](command);
+            const locale = 'en-US';
+            const commandParams = helpCommand['getCommandParams'](command, locale);
 
             expect(commandParams).toBe('**`optionname`** ');
         });
@@ -28,7 +29,8 @@ describe('HelpCommand', () => {
                 }
             } as unknown as BaseSlashCommandInteraction;
 
-            const commandParams = helpCommand['getCommandParams'](command);
+            const locale = 'en-US';
+            const commandParams = helpCommand['getCommandParams'](command, locale);
 
             expect(commandParams).toBe('');
         });


### PR DESCRIPTION
## Changes
- New translator where you specify locale, e.g. "en-US", this is because some places we do not have access to interaction object.
- Added translations for missing error messages, mostly handled in error events.
- Fixed missing translations for /systemstatus title
- Also translate command params (displayed in /help)
- Translate command names to norwegian for no locale

### Dependencies
- No changes
