### PR TITLE
fix: correct usage for deploying commands

### DIFF
--- a/src/startup/deploySlashCommands.ts
+++ b/src/startup/deploySlashCommands.ts
@@ -91,5 +91,8 @@ const rest: REST = new REST({ version: '10' }).setToken(process.env.DISCORD_BOT_
 })();
 
 async function refreshCommands(route: RouteLike, commands: object[]) {
-    await rest.put(route, { body: commands });
+    // Deploying Discord Commands, Runs POST call for each command Asynchronously
+    await Promise.all(commands.map(async (command) => {
+        await rest.post(route, { body: command });
+    }));
 }


### PR DESCRIPTION
DiscordJS documentation incorrectly tells people to use the "PUT" call, which is okay if the discord bot runs in isolation. However, Discord's API Commands "PUT" call will replace ALL commands that have been registered. Commands should be updated individually so as to not erase existing commands that are registered to the bot.

## Changes
Changes the deploySlashCommands.ts discord API call to asynchronously call discordJS's "rest.post" call for each command rather than using the "rest.put" for the entire set of commands. This way we don't erase commands added to the job from other bot applications running under the same token. 

