### PR TITLE
Fixing Docker Build Errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Images automatically published: docker pull mariusbegby/cadence
 
 # Using Node 18.16 (LTS) on bookworm-slim base
-ARG NODE_VERSION=18.16
+ARG NODE_VERSION=18.18
 FROM node:${NODE_VERSION}-bookworm-slim
 
 # Install npm build dependencies and ffmpeg

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY package*.json ./
 COPY tsconfig.json ./
 COPY src/ ./src/
 COPY config/ ./config/
+COPY locales/ ./locales/
 
 # Install dependencies from package-lock.json
 RUN npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY tsconfig.json ./
 COPY src/ ./src/
 COPY config/ ./config/
 COPY locales/ ./locales/
+COPY prisma/ ./prisma/
 
 # Install dependencies from package-lock.json
 RUN npm ci
@@ -26,6 +27,7 @@ RUN npm ci
 RUN npm run build && \
     rm -rf node_modules && \
     npm ci --omit=dev
+RUN npx prisma generate
 
 # Cleanup of unneeded packages, apk cache, and TypeScript source files
 RUN apt remove -y python3 make build-essential && \

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "strict": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
+        "noImplicitAny": false,
         "forceConsistentCasingInFileNames": true
     },
     "include": ["src/**/*.ts", "locales/**/*.ts"],


### PR DESCRIPTION
These changes correct a few issues that arise during the Docker container build process. 

## Changes
- adds missing locales and prisma copy to the Dockerfile
- adds missing type of `any` for the error return in guildDatabaseClient
- sets the typescript compiler option `noImplicitAny` to false
